### PR TITLE
python 2.6 support?

### DIFF
--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -52,10 +52,10 @@ class UploadCare(UploaderMixin):
         if self.api_version == '0.1':
             self.accept = 'application/json'
         else:
-            self.accept = 'application/vnd.uploadcare-v{}+json'.format(
+            self.accept = 'application/vnd.uploadcare-v{0}+json'.format(
                                 api_version)
         self.default_headers = {
-            'User-Agent': 'pyuploadcare/{}.{}'.format(*__version__),
+            'User-Agent': 'pyuploadcare/{0}.{1}'.format(*__version__),
         }
 
     def file(self, file_serialized):
@@ -124,17 +124,17 @@ class UploadCare(UploaderMixin):
                         hashlib.sha1).hexdigest()
 
         headers = self._build_headers({
-            'Authorization': 'Uploadcare {}:{}'.format(self.pub_key, sign),
+            'Authorization': 'Uploadcare {0}:{1}'.format(self.pub_key, sign),
             'Date': date,
             'Content-Type': content_type,
             'Content-Length': str(len(content)),
             'Accept': self.accept,
         })
         logger.debug('''sent:
-            verb: {}
-            path: {}
-            headers: {}
-            data: {}'''.format(verb, path, headers, content))
+            verb: {0}
+            path: {1}
+            headers: {2}
+            data: {3}'''.format(verb, path, headers, content))
 
         uri = self._build_api_uri(path)
         response = requests.request(verb, uri, allow_redirects=True,
@@ -147,7 +147,7 @@ class UploadCare(UploaderMixin):
             match = re.search('"(.+)"', response.headers['warning'])
             if match:
                 for warning in match.group(1).split('; '):
-                    logger.warn('API Warning: {}'.format(warning))
+                    logger.warn('API Warning: {0}'.format(warning))
 
         if response.status_code == 200: # Ok
             if response.json is None:

--- a/pyuploadcare/dj/forms.py
+++ b/pyuploadcare/dj/forms.py
@@ -34,11 +34,11 @@ class FileWidget(TextInput):
                 value = UploadCare().file(value)
 
             if value.url:
-                fname = '<a href="{}">{}</a>'.format(value.url, value.filename)
+                fname = '<a href="{0}">{1}</a>'.format(value.url, value.filename)
             else:
-                fname = '{} ({})'.format(value.filename, _('unavail.'))
+                fname = '{0} ({1})'.format(value.filename, _('unavail.'))
 
-            description = '<p>{}: {}</p>'.format(_('File'), fname)
+            description = '<p>{0}: {1}</p>'.format(_('File'), fname)
 
             html = mark_safe(html + description)
 

--- a/pyuploadcare/file.py
+++ b/pyuploadcare/file.py
@@ -108,11 +108,11 @@ class File(object):
 
     @property
     def api_uri(self):
-        return '/files/{}/'.format(self.file_id)
+        return '/files/{0}/'.format(self.file_id)
 
     @property
     def storage_uri(self):
-        return '/files/{}/storage/'.format(self.file_id)
+        return '/files/{0}/storage/'.format(self.file_id)
 
     def serialize(self):
         """Returns a string suitable to be stored somewhere.
@@ -149,9 +149,9 @@ class File(object):
                     "concatenated process command string")
         if not width or not height:
             raise ValueError('Need both width and height to crop')
-        dimensions = '{}x{}'.format(width, height)
+        dimensions = '{0}x{1}'.format(width, height)
 
-        return '{}-/crop/{}/'.format(self.cdn_url, dimensions)
+        return '{0}-/crop/{1}/'.format(self.cdn_url, dimensions)
 
     def resized(self, width=None, height=None):
         logger.warn("resized() is deprecated, use cdn_url with "
@@ -160,6 +160,6 @@ class File(object):
             raise ValueError('Need width or height to resize')
         dimensions = str(width) if width else ''
         if height:
-            dimensions += 'x{}'.format(height)
+            dimensions += 'x{0}'.format(height)
 
-        return '{}-/resize/{}/'.format(self.cdn_url, dimensions)
+        return '{0}-/resize/{1}/'.format(self.cdn_url, dimensions)

--- a/pyuploadcare/tests.py
+++ b/pyuploadcare/tests.py
@@ -129,7 +129,7 @@ class FileTest(unittest.TestCase):
         self.assertEqual('meh', f.url)
         self.assertEqual(1, len(request.mock_calls))
 
-        fake_url = 'http://i-am-the-file/{}/'.format(uuid)
+        fake_url = 'http://i-am-the-file/{0}/'.format(uuid)
         f = ucare.file(fake_url)
         self.assertEqual(fake_url, f.url)
         # no additional calls are made

--- a/pyuploadcare/ucare_cli.py
+++ b/pyuploadcare/ucare_cli.py
@@ -85,7 +85,7 @@ def _handle_uploaded_file(uf, args):
         pp.pprint(uf.info)
 
     if args.cdnurl:
-        print 'CDN url: {}'.format(uf.cdn_url)
+        print 'CDN url: {0}'.format(uf.cdn_url)
 
 
 def upload_from_url(args):
@@ -115,7 +115,7 @@ def upload(args):
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version',
-                        version='ucare {}.{}'.format(*__version__))
+                        version='ucare {0}.{1}'.format(*__version__))
 
     subparsers = parser.add_subparsers()
 

--- a/pyuploadcare/uploader.py
+++ b/pyuploadcare/uploader.py
@@ -20,7 +20,7 @@ class UploadedFile(object):
         self.data = None
 
     def __repr__(self):
-        return '<uploadcare.UploadedFile {} {}>'.format(self.url, self.status)
+        return '<uploadcare.UploadedFile {0} {1}>'.format(self.url, self.status)
 
     def update_status(self):
         self.status, self.data = self.uploader.get_status(self.token)
@@ -74,11 +74,11 @@ class UploaderMixin(object):
         )
         if response.status_code != 200:
             raise UploaderException(
-                'status code: {}'.format(response.status_code))
+                'status code: {0}'.format(response.status_code))
         data = json.loads(response.content)
         if 'token' not in data:
             raise UploaderException(
-                'could not find token in response: {}'.format(data))
+                'could not find token in response: {0}'.format(data))
         token = data['token']
         _file = UploadedFile(self, url, token)
         if wait:
@@ -97,11 +97,11 @@ class UploaderMixin(object):
 
         if response.status_code != 200:
             raise UploaderException(
-                'status code: {}'.format(response.status_code))
+                'status code: {0}'.format(response.status_code))
         data = json.loads(response.content)
         if 'status' not in data:
             raise UploaderException(
-                'could not find status in response: {}'.format(data))
+                'could not find status in response: {0}'.format(data))
 
         return data['status'], data
 
@@ -121,4 +121,4 @@ class UploaderMixin(object):
                     _file.ensure_on_s3(timeout=timeout)
                 return _file
             raise UploaderException(
-                'status code: {}'.format(response.status_code))
+                'status code: {0}'.format(response.status_code))


### PR DESCRIPTION
python 2.6 doesn't allow `zero length field name in format`. This fix of course should also work on 2.7 and 3.2(3).
