### PR TITLE
Updated setup.py to enforce utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,16 @@ requirements = [
 if PY_VERSION == (2, 6):
     requirements.append('argparse')
 
+if PY_VERSION < (3, 0):
+    long_description = open('README.rst').read() + '\n\n' + open('HISTORY.rst').read()
+else:
+    long_description = open('README.rst', encoding='utf-8').read() + '\n\n' + open('HISTORY.rst', encoding='utf-8').read()
 
 setup(
     name='pyuploadcare',
     version='1.2.12',
     description='Python library for Uploadcare.com',
-    long_description=(
-        open('README.rst').read() + '\n\n' + open('HISTORY.rst').read()
-    ),
+    long_description=(long_description),
     author='Uploadcare LLC',
     author_email='hello@uploadcare.com',
     url='https://github.com/uploadcare/pyuploadcare',


### PR DESCRIPTION
This is a fix that applies to Ubuntu 14.04, Python 3.4 and pip3 - not sure about older Python versions. I've encountered the issue described below on 2 separate Ubuntu 14.04 boxes, one of which is a very recent Digital Ocean Ubuntu 14.04 image.

It appears that if you don't explicitly set the encoding with ```locale.setlocale(locale.LC_ALL, 'en_US.utf-8')``` --- or whatever locale, just the encoding matters AFAIK --- python will try to decode the ```*.rst``` (```HISTORY.rst``` and ```README.rst```) files using ascii (the ```locale.getpreferredencoding(False)``` function that ```open()``` actually depends on for the type of encoding it uses returns ANSI_X3.4-1968). This generates an issue where Python will say it cannot decode the ```*.rst``` files using ascii and the installation will fail.

I've tested it by installing my fork.

Hope it saves other unknowing users some time :)
