### PR TITLE
Implement validation to check whether FileField's UUID is valid before storing it

### DIFF
--- a/pyuploadcare/dj/models.py
+++ b/pyuploadcare/dj/models.py
@@ -4,6 +4,8 @@ import re
 
 from django.db import models
 from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
 import six
 
 from . import forms
@@ -51,6 +53,16 @@ class FileField(six.with_metaclass(models.SubfieldBase, models.Field)):
         kwargs['form_class'] = forms.FileField
 
         return models.Field.formfield(self, **kwargs)
+
+    def validate(self, value, model_instance):
+        super(FileField, self).validate(value, model_instance)
+
+        try:
+            value.info()
+        except InvalidRequestError:
+            raise ValidationError(_('UUID to store could not be found on server: %(uuid)s'),
+                                  code='invalid_url',
+                                  params={'uuid': value.uuid})
 
     def clean(self, value, model_instance):
         cleaned_value = super(FileField, self).clean(value, model_instance)

--- a/pyuploadcare/dj/models.py
+++ b/pyuploadcare/dj/models.py
@@ -60,7 +60,7 @@ class FileField(six.with_metaclass(models.SubfieldBase, models.Field)):
         try:
             value.info()
         except InvalidRequestError:
-            raise ValidationError(_('UUID to store could not be found on server: %(uuid)s'),
+            raise ValidationError(_('The file with UUID %(uuid)s could not be found in your Uploadcare project'),
                                   code='invalid_url',
                                   params={'uuid': value.uuid})
 

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import os
+os.environ['DJANGO_SETTINGS_MODULE'] = 'test_project.settings'
+
+import django
+django.setup()
+
+from django import forms
+from django.db import models
+from pyuploadcare.dj import models as uc_models
+
+
+class ModelFormIntegrationTest(unittest.TestCase):
+
+    def test_validation_error_if_uuid_is_invalid(self):
+        class Employee(models.Model):
+            cv = uc_models.FileField()
+            class Meta:
+                app_label = 'tests.integration.test_models.test_validation_error_if_uuid_is_invalid.Employee'
+        class EmployeeForm(forms.ModelForm):
+            class Meta:
+                model = Employee
+                fields = ['cv']
+        form = EmployeeForm(data={'cv': '99999999-9999-9999-9999-999999999999'})
+        form.full_clean()
+        self.assertIsNotNone(form.errors)

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 from __future__ import unicode_literals
+from tests.integration.utils import upload_tmp_txt_file
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'test_project.settings'
 
@@ -16,17 +18,29 @@ from django.db import models
 from pyuploadcare.dj import models as uc_models
 
 
+class Employee(models.Model):
+    cv = uc_models.FileField()
+    class Meta:
+        app_label = 'tests.integration.test_models.Employee'
+
+
+class EmployeeForm(forms.ModelForm):
+    class Meta:
+        model = Employee
+        fields = ['cv']
+
+
 class ModelFormIntegrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_ = upload_tmp_txt_file(content='hello')
+
+    def test_no_validation_error_if_uuid_is_valid(self):
+        form = EmployeeForm(data={'cv': ModelFormIntegrationTest.file_.uuid})
+        form.full_clean()
+        self.assertEquals(form.errors, {})
 
     def test_validation_error_if_uuid_is_invalid(self):
-        class Employee(models.Model):
-            cv = uc_models.FileField()
-            class Meta:
-                app_label = 'tests.integration.test_models.test_validation_error_if_uuid_is_invalid.Employee'
-        class EmployeeForm(forms.ModelForm):
-            class Meta:
-                model = Employee
-                fields = ['cv']
         form = EmployeeForm(data={'cv': '99999999-9999-9999-9999-999999999999'})
         form.full_clean()
         self.assertIsNotNone(form.errors)


### PR DESCRIPTION
This PR is based on an earlier support request.

The use case is an ImageField which is used on an model that's accessed in a non-customized Django admin. If a model contains an invalid Uploadcare URL in an ImageField, it's impossible to store that model in the admin, even without making changes.
Attempting to store the model in the admin results not in a validation error, but rather in a hard, uncaught exception: `InvalidRequestError: {"detail":"Not found."}`

This PR tries to change this into a validation error, the same case would now look like this:

![2015-09-09_1625](https://cloud.githubusercontent.com/assets/159414/9764423/5d151bac-570f-11e5-8101-bfcc81163d16.png)

There's probably some more tasks necessary before this can be merged:

* I'm not quite sure what preconditions have to be fulfilled to make `pyuploadcare.api_resources.File#store()` a valid operation (I still don't really understand the concept of 'storing' in Uploadcare), so I'm just making a `pyuploadcare.api_resources.File#update_info()` test call.

* The validation error message could be improved (too technical for users of the Django admin).

* I'm sure the test case could be streamlined (and made compatible with pre-Django 1.7), this is just the simplest test case I managed to create that worked on Django 1.8.

* I suspect the same change will have to be made for `FileGroupField`.

* It's still not possible to remove an invalid image (there's no 'remove' button, see the above screenshot!). But I believe that's an issue in the Uploadcare Widget JS, and not in pyuploadcare.