### PR TITLE
Fix RTD build error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from .pyuploadcare import __version__
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.3.1'
+#needs_sphinx = '1.3.1'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.


### PR DESCRIPTION
I just remove `needs_sphinx = '1.3.1'` param from `conf.py` because RTD error:

```
Sphinx version error:
This project needs at least Sphinx v1.3.1 and therefore cannot be built with this version.
```

And then builded own documentation. 

All seems ok: http://pyuploadcare-zero.readthedocs.org/en/zerc-fix-rtd/