### PR TITLE
django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 sudo: false
 language: python
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6
@@ -14,6 +13,7 @@ env:
     - DJANGO=1.8
     - DJANGO=1.9
     - DJANGO=1.10
+    - DJANGO=1.11
     - DJANGO=2.0
 matrix:
   include:
@@ -28,12 +28,17 @@ matrix:
       env: DJANGO=1.6
     - python: 2.7
       env: DJANGO=1.7
+    - python: 2.7
+      env: DJANGO=1.8
+    - python: 2.7
+      env: DJANGO=1.9
+    - python: 2.7
+      env: DJANGO=1.10
+    - python: 2.7
+      env: DJANGO=1.11
 
     - python: 3.3
       env: DJANGO=1.8
-
-    - python: 3.6
-      env: DJANGO=2.0
 
     # integration tests
     - stage: integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 env:
   global:
     - SUITE="tests/functional"
@@ -13,6 +14,7 @@ env:
     - DJANGO=1.8
     - DJANGO=1.9
     - DJANGO=1.10
+    - DJANGO=2.0
 matrix:
   include:
     - python: 2.6
@@ -29,6 +31,9 @@ matrix:
 
     - python: 3.3
       env: DJANGO=1.8
+
+    - python: 3.6
+      env: DJANGO=2.0
 
     # integration tests
     - stage: integration tests

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 ~~~~~
 
 - Add support for django versions 1.11 and ~2.0
-- Miscellaneous updates(version, year in a licence file, tox configuration and etc.)
+- Miscellaneous updates(version, year in a license file, tox configuration and etc.)
 
 2.2.1
 ~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 -------
 
-2.2.1
+2.3.0
 ~~~~~
 
 - Add support for django versions 1.11 and ~2.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 2.2.1
 ~~~~~
 
+- Add support for django versions 1.11 and ~2.0
+- Miscellaneous updates(version, year in a licence file, tox configuration and etc.)
+
+2.2.1
+~~~~~
+
 - Add ``file.create_local_copy`` and ``file.create_remote_copy`` methods.
 - Add new ``make_public`` and ``pattern`` parameters to file.create_remote_copy method.
 - Add new ``store`` parameter to file.create_local_copy methods.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Uploadcare, LLC
+Copyright (c) 2018 Uploadcare, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Features
 Requirements
 ------------
 
-``pyuploadcare`` requires Python 2.6, 2.7, 3.3, 3.4 or 3.5.
+``pyuploadcare`` requires Python 2.6, 2.7, 3.3, 3.4, 3.5 or 3.6
 
 If you're using ``pyuploadcare`` with Django, check ``.travis.yml`` for supported
 Python-Django combinations.
@@ -105,6 +105,7 @@ Contributors
 - `@zerc`_
 - `@homm`_
 - `@va1en0k`_
+- `@andreshkovskii`_
 
 .. _Uploadcare: https://uploadcare.com/
 .. _simple steps: https://pyuploadcare.readthedocs.org/en/latest/quickstart.html
@@ -117,3 +118,4 @@ Contributors
 .. _@zerc: https://github.com/zerc
 .. _@homm: https://github.com/homm
 .. _@va1en0k: https://github.com/va1en0k
+.. _@andreshkovskii: https://github.com/andrewshkovskii/

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -15,7 +15,7 @@ Usage example::
 
 from __future__ import unicode_literals
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 
 from .api_resources import File, FileList, FileGroup
 from .exceptions import (

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -15,7 +15,7 @@ Usage example::
 
 from __future__ import unicode_literals
 
-__version__ = '2.2.2'
+__version__ = '2.3.0'
 
 from .api_resources import File, FileList, FileGroup
 from .exceptions import (

--- a/pyuploadcare/dj/models.py
+++ b/pyuploadcare/dj/models.py
@@ -45,7 +45,7 @@ class FileField(six.with_metaclass(SubfieldBase, models.Field)):
             return value.cdn_url
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def formfield(self, **kwargs):
@@ -158,7 +158,7 @@ class FileGroupField(six.with_metaclass(SubfieldBase, models.Field)):
             return value.cdn_url
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def formfield(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ else:
 
 setup(
     name='pyuploadcare',
-    version='2.2.2',
+    version='2.3.0',
     description='Python library for Uploadcare.com',
     long_description=(long_description),
     author='Uploadcare LLC',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ else:
 
 setup(
     name='pyuploadcare',
-    version='2.2.1',
+    version='2.2.2',
     description='Python library for Uploadcare.com',
     long_description=(long_description),
     author='Uploadcare LLC',
@@ -58,6 +58,8 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'License :: OSI Approved :: MIT License',
     ],
 )

--- a/tests/test_project/gallery/models.py
+++ b/tests/test_project/gallery/models.py
@@ -13,7 +13,7 @@ class Gallery(models.Model):
 
 class Photo(models.Model):
 
-    gallery = models.ForeignKey(Gallery)
+    gallery = models.ForeignKey(Gallery, on_delete=models.CASCADE)
     title = models.CharField(max_length=255)
     arbitrary_file = FileField(blank=True, null=True)
     photo_2x3 = ImageField(manual_crop='2:3', blank=True)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
-    py36: python3.5
+    py36: python3.6
 deps =
     pytest
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26-dj1.6,py27-dj1.{4,5,6,7,8,9,10,11},py{33}-dj1.8,py{34}-dj{1.8,1.9,1.10,1.11,2.0},py{35}-dj{1.8,1.9,1.10,1.11,2.0}
+envlist=py26-dj1.6,py27-dj1.{4,5,6,7,8,9,10,11},py{33}-dj1.8,py3{4,5,6}-dj{1.8,1.9,1.10,1.11,2.0}
 
 [testenv]
 basepython =
@@ -8,6 +8,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.5
 deps =
     pytest
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26-dj1.6,py27-dj1.{4,5,6,7,8,9,10},py{33}-dj1.8,py{34}-dj1.{8,9,10},py{35}-dj1.{8,9,10}
+envlist=py26-dj1.6,py27-dj1.{4,5,6,7,8,9,10,11},py{33}-dj1.8,py{34}-dj{1.8,1.9,1.10,1.11,2.0},py{35}-dj{1.8,1.9,1.10,1.11,2.0}
 
 [testenv]
 basepython =
@@ -19,5 +19,7 @@ deps =
     dj1.8: Django~=1.8.0
     dj1.9: Django~=1.9.0
     dj1.10: Django~=1.10.0
+    dj1.11: Django~=1.11.0
+    dj2.0: Django~=2.0.0
 commands =
     py.test tests


### PR DESCRIPTION
This PR make available to use `pyuploadcare` with django 2.0
Version 1.11 will be also supported.

REFS: #131 