### PR TITLE
Fixes missing renderer for Django 2.1

### DIFF
--- a/pyuploadcare/dj/forms.py
+++ b/pyuploadcare/dj/forms.py
@@ -41,8 +41,8 @@ class FileWidget(TextInput):
 
         super(FileWidget, self).__init__(default_attrs)
 
-    def render(self, name, value, attrs):
-        return super(FileWidget, self).render(name, value, attrs)
+    def render(self, name, value, attrs, renderer=None):
+        return super(FileWidget, self).render(name, value, attrs, renderer)
 
 
 class FileField(Field):


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is removed.
Reference for the fix: https://github.com/splaroche/django-froala-editor/commit/eda8d5e5a331520740e44bc9e8d6f18dbb05406c