### PR TITLE
Feature/fix tests models warnings

### DIFF
--- a/tests/dj/test_forms.py
+++ b/tests/dj/test_forms.py
@@ -27,7 +27,7 @@ class FormFieldsAttributesTest(unittest.TestCase):
             ff = uc_forms.FileField()
 
         f = SomeForm(label_suffix="")
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(f.media),
             r"https://ucarecdn\.com/libs/widget/[\d\.x]+/uploadcare\.full.min\.js",
         )
@@ -43,7 +43,7 @@ class FormFieldsAttributesTest(unittest.TestCase):
             )
 
         f = SomeForm(label_suffix="")
-        self.assertRegexpMatches(
+        self.assertRegex(
             str(f.media),
             r"https://ucarecdn\.com/libs/widget/[\d\.x]+/uploadcare\.full\.min\.js",
         )

--- a/tests/dj/test_models.py
+++ b/tests/dj/test_models.py
@@ -49,39 +49,45 @@ class FileFieldTest(unittest.TestCase):
         class Meta:
             app_label = "tests"
 
-        bases = (models.Model, )
-        attributes = {
-            'Meta': Meta,
-            'cv': cv_field,
-            '__module__': __name__
-        }
-        return type(f'Employee_{label}', bases, attributes)
+        bases = (models.Model,)
+        attributes = {"Meta": Meta, "cv": cv_field, "__module__": __name__}
+        return type(f"Employee_{label}", bases, attributes)
 
     def test_empty_str_is_allowed(self):
-        Employee = self._construct_Employee_class_with_variations('blank', FileField(blank=True))
+        Employee = self._construct_Employee_class_with_variations(
+            "blank", FileField(blank=True)
+        )
         emp = Employee()
         self.assertEqual(emp.cv, "")
 
     def test_null_is_allowed(self):
-        Employee = self._construct_Employee_class_with_variations('null', FileField(null=True))
+        Employee = self._construct_Employee_class_with_variations(
+            "null", FileField(null=True)
+        )
 
         emp = Employee(cv=None)
         self.assertEqual(emp.cv, None)
 
     def test_validation_error_if_value_is_int(self):
-        Employee = self._construct_Employee_class_with_variations('int', FileField())
+        Employee = self._construct_Employee_class_with_variations(
+            "int", FileField()
+        )
 
         with self.assertRaises(ValidationError):
             Employee(cv=123)
 
     def test_validation_error_if_uuid_is_invalid_str(self):
-        Employee = self._construct_Employee_class_with_variations('invalid_str', FileField())
+        Employee = self._construct_Employee_class_with_variations(
+            "invalid_str", FileField()
+        )
 
         with self.assertRaises(ValidationError):
             Employee(cv="123")
 
     def test_file_instance_if_uuid_is_valid(self):
-        Employee = self._construct_Employee_class_with_variations('valid_uuid_str', FileField())
+        Employee = self._construct_Employee_class_with_variations(
+            "valid_uuid_str", FileField()
+        )
 
         emp = Employee(cv="3addab78-6368-4c55-ac08-22412b6a2a4c")
         self.assertIsInstance(emp.cv, File)
@@ -92,40 +98,50 @@ class FileGroupFieldTest(unittest.TestCase):
         class Meta:
             app_label = "tests"
 
-        bases = (models.Model, )
+        bases = (models.Model,)
         attributes = {
-            'Meta': Meta,
-            'pages': pages_field,
-            '__module__': __name__
+            "Meta": Meta,
+            "pages": pages_field,
+            "__module__": __name__,
         }
-        return type(f'Book_{label}', bases, attributes)
+        return type(f"Book_{label}", bases, attributes)
 
     def test_empty_str_is_allowed(self):
-        Book = self._construct_Book_class_with_variations('empty', FileGroupField(blank=True))
+        Book = self._construct_Book_class_with_variations(
+            "empty", FileGroupField(blank=True)
+        )
 
         book = Book()
         self.assertEqual(book.pages, "")
 
     def test_null_is_allowed(self):
-        Book = self._construct_Book_class_with_variations('null', FileGroupField(null=True))
+        Book = self._construct_Book_class_with_variations(
+            "null", FileGroupField(null=True)
+        )
 
         book = Book(pages=None)
         self.assertEqual(book.pages, None)
 
     def test_validation_error_if_value_is_int(self):
-        Book = self._construct_Book_class_with_variations('int', FileGroupField())
+        Book = self._construct_Book_class_with_variations(
+            "int", FileGroupField()
+        )
 
         with self.assertRaises(ValidationError):
             Book(pages=123)
 
     def test_validation_error_if_group_id_is_invalid_str(self):
-        Book = self._construct_Book_class_with_variations('invalid_str', FileGroupField())
+        Book = self._construct_Book_class_with_variations(
+            "invalid_str", FileGroupField()
+        )
 
         with self.assertRaises(ValidationError):
             Book(pages="123")
 
     def test_file_group_instance_if_group_id_is_valid(self):
-        Book = self._construct_Book_class_with_variations('valid_str', FileGroupField())
+        Book = self._construct_Book_class_with_variations(
+            "valid_str", FileGroupField()
+        )
 
         book = Book(pages="0513dda0-582f-447d-846f-096e5df9e2bb~2")
         self.assertIsInstance(book.pages, FileGroup)

--- a/tests/dj/test_models.py
+++ b/tests/dj/test_models.py
@@ -45,104 +45,87 @@ class CropToolRegexTest(unittest.TestCase):
 
 
 class FileFieldTest(unittest.TestCase):
+    def _construct_Employee_class_with_variations(self, label, cv_field):
+        class Meta:
+            app_label = "tests"
+
+        bases = (models.Model, )
+        attributes = {
+            'Meta': Meta,
+            'cv': cv_field,
+            '__module__': __name__
+        }
+        return type(f'Employee_{label}', bases, attributes)
+
     def test_empty_str_is_allowed(self):
-        class Employee(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            cv = FileField(blank=True)
-
+        Employee = self._construct_Employee_class_with_variations('blank', FileField(blank=True))
         emp = Employee()
         self.assertEqual(emp.cv, "")
 
     def test_null_is_allowed(self):
-        class Employee(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            cv = FileField(null=True)
+        Employee = self._construct_Employee_class_with_variations('null', FileField(null=True))
 
         emp = Employee(cv=None)
         self.assertEqual(emp.cv, None)
 
     def test_validation_error_if_value_is_int(self):
-        class Employee(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            cv = FileField()
+        Employee = self._construct_Employee_class_with_variations('int', FileField())
 
         with self.assertRaises(ValidationError):
             Employee(cv=123)
 
     def test_validation_error_if_uuid_is_invalid_str(self):
-        class Employee(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            cv = FileField()
+        Employee = self._construct_Employee_class_with_variations('invalid_str', FileField())
 
         with self.assertRaises(ValidationError):
             Employee(cv="123")
 
     def test_file_instance_if_uuid_is_valid(self):
-        class Employee(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            cv = FileField()
+        Employee = self._construct_Employee_class_with_variations('valid_uuid_str', FileField())
 
         emp = Employee(cv="3addab78-6368-4c55-ac08-22412b6a2a4c")
         self.assertIsInstance(emp.cv, File)
 
 
 class FileGroupFieldTest(unittest.TestCase):
-    def test_empty_str_is_allowed(self):
-        class Book(models.Model):
-            class Meta:
-                app_label = "tests"
+    def _construct_Book_class_with_variations(self, label, pages_field):
+        class Meta:
+            app_label = "tests"
 
-            pages = FileGroupField(blank=True)
+        bases = (models.Model, )
+        attributes = {
+            'Meta': Meta,
+            'pages': pages_field,
+            '__module__': __name__
+        }
+        return type(f'Book_{label}', bases, attributes)
+
+    def test_empty_str_is_allowed(self):
+        Book = self._construct_Book_class_with_variations('empty', FileGroupField(blank=True))
 
         book = Book()
         self.assertEqual(book.pages, "")
 
     def test_null_is_allowed(self):
-        class Book(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            pages = FileGroupField(null=True)
+        Book = self._construct_Book_class_with_variations('null', FileGroupField(null=True))
 
         book = Book(pages=None)
         self.assertEqual(book.pages, None)
 
     def test_validation_error_if_value_is_int(self):
-        class Book(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            pages = FileGroupField()
+        Book = self._construct_Book_class_with_variations('int', FileGroupField())
 
         with self.assertRaises(ValidationError):
             Book(pages=123)
 
     def test_validation_error_if_group_id_is_invalid_str(self):
-        class Book(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            pages = FileGroupField()
+        Book = self._construct_Book_class_with_variations('invalid_str', FileGroupField())
 
         with self.assertRaises(ValidationError):
             Book(pages="123")
 
     def test_file_group_instance_if_group_id_is_valid(self):
-        class Book(models.Model):
-            class Meta:
-                app_label = "tests"
-
-            pages = FileGroupField()
+        Book = self._construct_Book_class_with_variations('valid_str', FileGroupField())
 
         book = Book(pages="0513dda0-582f-447d-846f-096e5df9e2bb~2")
         self.assertIsInstance(book.pages, FileGroup)


### PR DESCRIPTION
## Description

Fix warnings in tests:
- use factories for the same django models with local attribute variations
- use assertRegex instead of assertRegexpMatches


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
