### PR TITLE
Fix header name in ThrottledRequestError

### DIFF
--- a/pyuploadcare/exceptions.py
+++ b/pyuploadcare/exceptions.py
@@ -39,7 +39,7 @@ class ThrottledRequestError(UploadcareException):
     def __init__(self, response):
         try:
             self.wait = int(
-                response.headers.get("x-throttle-wait-seconds", 15)
+                response.headers.get("retry-after", 15)
             )
         except ValueError:
             self.wait = 15

--- a/pyuploadcare/exceptions.py
+++ b/pyuploadcare/exceptions.py
@@ -38,9 +38,7 @@ class ThrottledRequestError(UploadcareException):
 
     def __init__(self, response):
         try:
-            self.wait = int(
-                response.headers.get("retry-after", 15)
-            )
+            self.wait = int(response.headers.get("retry-after", 15))
         except ValueError:
             self.wait = 15
         self.wait += 1


### PR DESCRIPTION
Both rest and upload api return `Retry-After`. 

Related:
* https://uploadcare.com/api-refs/upload-api/#tag/Upload
* https://uploadcare.com/api-refs/rest-api/v0.7.0/#operation/filesList