### PR TITLE
freeze httpx version 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0]() - 2022-10-24
+## [3.1.1](https://github.com/uploadcare/pyuploadcare/compare/v3.1.0...v3.1.1) - TBD
+
+### Changed
+
+  - freeze `httpx` dependency for py37+ (`=0.23.0`) to prevent breaking changes in processing files opened in text mode
+
+## [3.1.0](https://github.com/uploadcare/pyuploadcare/compare/v3.0.1...v3.1.0) - 2022-10-24
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyuploadcare"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python library for Uploadcare.com"
 authors = ["Uploadcare Inc <hello@uploadcare.com>"]
 readme = "README.md"
@@ -28,7 +28,7 @@ ucare = 'pyuploadcare.ucare_cli.main:main'
 python = "^3.6.2"
 httpx = [
   {version = "^0.18.2", python = ">=3.6,<3.7"},
-  {version = "^0.23.0", python = "^3.7"}
+  {version = "0.23.0", python = "^3.7"}
 ]
 pydantic = {extras = ["email"], version = "^1.8.2"}
 python-dateutil = "^2.8.2"

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-__version__ = "3.0.1"
+__version__ = "3.1.1"
 
 from pyuploadcare.resources.file import File  # noqa: F401
 from pyuploadcare.resources.file_group import FileGroup  # noqa: F401


### PR DESCRIPTION
## Description

- `httpx` with upgrading from [`0.23.0` to `0.23.1`](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0231) prevents uploading of files opened [not in binary mode](https://github.com/encode/httpx/pull/2400). Potentially that may brake some expected flows, so it's better to freeze version of `httpx`
- freeze `httpx` version for py3.7+ used with REST API v0.6

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
