### PR TITLE
Test against newer versions of Python and fix the test workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,14 @@ jobs:
           # django versions that support py3.10
           - python-version: '3.10'
             django-version: 3.2
+          - python-version: '3.10'
+            django-version: 4.0
+
+          # django versions that support py3.11
+          - python-version: '3.11'
+            django-version: 4.1
+          - python-version: '3.11'
+            django-version: 4.2
 
     steps:
     - uses: actions/checkout@v2
@@ -117,7 +125,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: 1.1.15
+        version: 1.4.2
         virtualenvs-create: true
         virtualenvs-in-project: false
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -43,7 +43,7 @@ jobs:
         #     python-version: '3.6'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -71,7 +71,7 @@ jobs:
         python-version: ['3.6']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -117,7 +117,7 @@ jobs:
             django-version: 4.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -150,7 +150,7 @@ jobs:
         django-version: ['1.11', '2.2', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -179,7 +179,7 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
         # include:
         #   - os: ubuntu-20.04
         #     python-version: '3.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-          - os: ubuntu-20.04
-            python-version: '3.6'
+        # include:
+        #   - os: ubuntu-20.04
+        #     python-version: '3.6'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         # include:
         #   - os: ubuntu-20.04
         #     python-version: '3.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
-        # include:
-        #   - os: ubuntu-20.04
-        #     python-version: '3.6'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@
 
 name: Tests
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - 'main'
+    - 'feature/**'
+    - 'version-3.x/**'
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: 1.1.15  # needed for py3.6
+        version: 1.4.2
         virtualenvs-create: true
         virtualenvs-in-project: false
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,34 @@ jobs:
       run: |
         make test-functional
 
+  functional-legacy-py:
+    needs: lint
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ['3.6']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.1.15
+        virtualenvs-create: true
+        virtualenvs-in-project: false
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Test with pytest
+      run: |
+        make test-functional
+
   django:
     needs: functional
     runs-on: ubuntu-latest
@@ -103,7 +131,7 @@ jobs:
         make test-django
 
   django-legacy-py:
-    needs: functional
+    needs: functional-legacy-py
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,8 @@
 
 name: Tests
 on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - 'main'
-    - 'feature/**'
-    - 'version-3.x/**'
+  - push
+  - pull_request
 
 jobs:
   lint:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Features
 Requirements
 ============
 
-``pyuploadcare`` requires Python 3.6, 3.7, 3.8, 3.9, 3.10
+``pyuploadcare`` requires Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 
 To use ``pyuploadcare`` with Python 2.7 please install ``pyuploadcare < 3.0``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ flake8 = "^3.9.2"
 mypy = "^0.910"
 flake8-print = "^4.0.0"
 pytest-vcr = "^1.0.2"
+yarl = [
+    {version = "^1.7.2", python = ">=3.6,<3.7"},
+    {version = "^1.9.2", python = "^3.7"}
+]
 Django = "^3.2.7"
 pytest-cov = "^2.12.1"
 python-coveralls = "^2.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: MIT License',
 ]
 
@@ -59,6 +60,10 @@ yarl = [
     {version = "^1.9.2", python = "^3.7"}
 ]
 Django = "^3.2.7"
+coverage = [
+    {version = "^6.2", python = ">=3.6,<3.7"},
+    {version = "^7.2.5", python = "^3.7"}
+]
 pytest-cov = "^2.12.1"
 python-coveralls = "^2.9.3"
 tox-pyenv = "^1.1.0"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 isolated_build = True
 envlist=
         # core lib tests
-        py{36,37,38,39,310}-api,
+        py{36,37,38,39,310,311}-api,
 
         # old django versions
         py{36,37}-dj1.11-django
@@ -30,6 +30,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 deps =
     pytest
     mock


### PR DESCRIPTION
All tests are green now.

1. Added support for running tests against Python 3.11 as well as Python 3.12 (alpha).
2. Updated the test workflow to use newer versions of `poetry`, `yarl`, and `coverage` as the older versions were incompatible with Python 3.11. However, testing against Python 3.6 still uses the old versions of those packages.
3. Replaced `actions/checkout@v2` with `actions/checkout@v3` to suppress the deprecation notice.
4. <s>Enabled the test workflow for all branches, not just `main`.</s>

Supersedes #214.