### PR TITLE
Add check_duplicates and save_duplicates parameters to upload_from_url[_sync]

### DIFF
--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -26,7 +26,7 @@ from pyuploadcare.api.base import (
 )
 from pyuploadcare.exceptions import (
     APIError,
-    FileAlreadyUploaded,
+    DuplicateFileError,
     InvalidRequestError,
     WebhookIsNotUnique,
 )
@@ -393,7 +393,7 @@ class UploadAPI(API):
         if "token" not in response:
             if check_duplicates and response["type"] == "file_info":
                 file_id = response["file_id"]
-                raise FileAlreadyUploaded(
+                raise DuplicateFileError(
                     f"The file is a duplicate of a previously uploaded file ({file_id})",
                     file_id=file_id,
                 )

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -28,7 +28,7 @@ from pyuploadcare.api import (
 from pyuploadcare.api.auth import UploadcareAuth
 from pyuploadcare.api.client import Client
 from pyuploadcare.api.entities import ProjectInfo, Webhook
-from pyuploadcare.exceptions import FileAlreadyUploaded, InvalidParamError
+from pyuploadcare.exceptions import DuplicateFileError, InvalidParamError
 from pyuploadcare.helpers import (
     extracts_uuids,
     get_file_size,
@@ -474,7 +474,7 @@ class Uploadcare:
                 or source URL. Defaults to None.
             - check_duplicates (Optional[bool]): Enables duplicate uploads
                 prevention. If a file with the same source URL has been
-                previously uploaded this method will raise FileAlreadyUploaded.
+                previously uploaded this method will raise DuplicateFileError.
             - save_duplicates (Optional[bool]): Indicates if the URL should be
                 stored by Uploadcare future check_duplicates usages.
 
@@ -565,7 +565,7 @@ class Uploadcare:
                 until_ready=until_ready,
                 callback=callback,
             )
-        except FileAlreadyUploaded as e:
+        except DuplicateFileError as e:
             return self.file(e.file_id)
 
     def _extract_uuids(

--- a/pyuploadcare/exceptions.py
+++ b/pyuploadcare/exceptions.py
@@ -59,7 +59,7 @@ class UploadError(UploadcareException):
     """
 
 
-class FileAlreadyUploaded(UploadError):
+class DuplicateFileError(UploadError):
     """Raised within UploadAPI.upload_from_url if check_duplicates is True and file was already been uploaded before)"""
 
     file_id: str

--- a/pyuploadcare/exceptions.py
+++ b/pyuploadcare/exceptions.py
@@ -59,6 +59,16 @@ class UploadError(UploadcareException):
     """
 
 
+class FileAlreadyUploaded(UploadError):
+    """Raised within UploadAPI.upload_from_url if check_duplicates is True and file was already been uploaded before)"""
+
+    file_id: str
+
+    def __init__(self, message: str, file_id: str) -> None:
+        super().__init__(message)
+        self.file_id = file_id
+
+
 class DefaultResponseClassNotDefined(Exception):
     def __init__(self) -> None:
         super().__init__("Need define default response class for API.")

--- a/tests/integration/test_api_resources.py
+++ b/tests/integration/test_api_resources.py
@@ -11,7 +11,7 @@ import pytest
 
 from pyuploadcare import File, FileGroup, conf
 from pyuploadcare.exceptions import (
-    FileAlreadyUploaded,
+    DuplicateFileError,
     InvalidParamError,
     InvalidRequestError,
 )
@@ -139,9 +139,9 @@ def test_successful_upload_from_url_check_duplicates(uploadcare):
         url, check_duplicates=True, store=False, interval=1
     )
     assert isinstance(first_file, File)
-    with pytest.raises(FileAlreadyUploaded) as e:
+    with pytest.raises(DuplicateFileError) as e:
         uploadcare.upload_from_url(url, check_duplicates=True, store=False)
-        assert isinstance(e, FileAlreadyUploaded)
+        assert isinstance(e, DuplicateFileError)
         assert first_file.uuid == e.file_id
 
 


### PR DESCRIPTION
Support for `check_URL_duplicates` and `save_URL_duplicates` API parameters has been added when calling `Uploadcare.upload_from_url` or `Uploadcare.upload_from_url_sync`.

API: https://uploadcare.com/api-refs/upload-api/#tag/Upload/operation/fromURLUpload

Addresses #239 

Usage example:

```python
from pyuploadcare import Uploadcare

uploadcare = Uploadcare(public_key="YOUR_PUBLIC_KEY", secret_key="YOUR_SECRET_KEY")

# Raises FileAlreadyUploaded if duplicate (as we can't return FileFromUrl without a token).
# Returns FileFromUrl instance if not.
file_from_url = uploadcare.upload_from_url("https://source.unsplash.com/random", check_duplicates=True) 

# Always returns File instance (if upload is a duplicate it returns the old one).
file = uploadcare.upload_from_url_sync("https://source.unsplash.com/random", check_duplicates=True) 
```

- [ ] Should the universal `Uploadcare.upload` method have this feature as well? On one hand, it makes sense, but on the other hand, I didn't want it to become bloated.
