### PR TITLE
Fix flake8 warnings (after #239 #240) and update HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,20 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.x] - unreleased
+
+### Added
+
+- For `Uploadcare` and `UploadAPI`:
+  - `upload_from_url` and `upload_from_url_sync` can now accept two new optional parameters: `check_duplicates` and `save_duplicates`. These correspond to `check_URL_duplicates` and `save_URL_duplicates` for [`/from_url/` upload API endpoint](https://uploadcare.com/api-refs/upload-api/#tag/Upload/operation/fromURLUpload) respectively.
+
+### Changed
+
+- Bumped `yarl` dev dependency for py37+.
+- Bumped `coverage` dev dependency for py37+.
+- Tests are now run against Python 3.11 and 3.12 (alpha) as well. The minimum supported version of Python remains 3.6.
+- Tests are now run against Django 4.0, 4.1 and 4.2 as well. The minimum supported version of Django remains 1.11.
+
 ## [4.0.0](https://github.com/uploadcare/pyuploadcare/compare/v3.2.0...v4.0.0) - 2022-12-26
 
 Now uses [REST API v0.7](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Changelog).

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -346,7 +346,7 @@ class UploadAPI(API):
         document = self._client.post(url, data=data)
         return document.json()
 
-    def upload_from_url(
+    def upload_from_url(  # noqa: max-complexity: 8
         self,
         source_url,
         store="auto",

--- a/pyuploadcare/exceptions.py
+++ b/pyuploadcare/exceptions.py
@@ -60,7 +60,10 @@ class UploadError(UploadcareException):
 
 
 class DuplicateFileError(UploadError):
-    """Raised within UploadAPI.upload_from_url if check_duplicates is True and file was already been uploaded before)"""
+    """
+    Raised within UploadAPI.upload_from_url if check_duplicates is True
+    and file was already been uploaded before)
+    """
 
     file_id: str
 


### PR DESCRIPTION
```
./pyuploadcare/exceptions.py:63:101: E501 line too long (120 > 100 characters)
./pyuploadcare/api/api.py:349:5: C901 'UploadAPI.upload_from_url' is too complex (8)
```