### PR TITLE
Add CodeQL workflow for GitHub code scanning (on top of the newer codebase)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "48 12 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
LGTM.com has migrated to GitHub code scanning and it automatically created a pull request. However, the base of the pull request is an older version of pyuploadcare. Please refer to #231 for more details.

The file `.github/workflows/codeql.yml` has been added from that pull request.

~~This pull request will generate some alerts that need to be addressed here.~~ If not, then look at the alerts generated in #231 
UPD. It did not.