### PR TITLE
Bump httpx version #243

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Bumped `httpx` dependency for py37+.
 - Bumped `yarl` dev dependency for py37+.
 - Bumped `coverage` dev dependency for py37+.
 - Tests are now run against Python 3.11 and 3.12 (alpha) as well. The minimum supported version of Python remains 3.6.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ ucare = 'pyuploadcare.ucare_cli.main:main'
 python = "^3.6.2"
 httpx = [
   {version = "^0.18.2", python = ">=3.6,<3.7"},
-  {version = "^0.23.0", python = "^3.7"}
+  {version = "^0.24.1", python = "^3.7"}
 ]
 pydantic = {extras = ["email"], version = "^1.8.2"}
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
```
  • Updating httpcore (0.16.3 -> 0.17.2)
  • Updating httpx (0.23.3 -> 0.24.1)
```

No breaking API changes in both [httpx](https://github.com/encode/httpx/blob/master/CHANGELOG.md) and [httpcore](https://github.com/encode/httpcore/blob/master/CHANGELOG.md)