### PR TITLE
Helper methods for deleting file groups with their contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 pyuploadcare.egg-info/
 temp.db
+uploadcare.ini
 build/
 dist/
 docs/_build

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,10 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - For `Uploadcare` and `UploadAPI`:
   - `upload_from_url` and `upload_from_url_sync` can now accept two new optional parameters: `check_duplicates` and `save_duplicates`. These correspond to `check_URL_duplicates` and `save_URL_duplicates` for [`/from_url/` upload API endpoint](https://uploadcare.com/api-refs/upload-api/#tag/Upload/operation/fromURLUpload) respectively.
-- For `Uploadcare`:
-  - `delete_file_group_with_files` method that not only deletes a file group but also deletes all the files within that group.
 - For `FileGroup`:
-  - `delete_with_files` method that not only deletes a file group, but also deletes all files in that group.
+  - The `delete` method now includes an optional `delete_files` argument, which indicates whether the files within the specified group should also be deleted.
 
 ### Changed
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,12 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.x] - unreleased
+## Unreleased
 
 ### Added
 
 - For `Uploadcare` and `UploadAPI`:
   - `upload_from_url` and `upload_from_url_sync` can now accept two new optional parameters: `check_duplicates` and `save_duplicates`. These correspond to `check_URL_duplicates` and `save_URL_duplicates` for [`/from_url/` upload API endpoint](https://uploadcare.com/api-refs/upload-api/#tag/Upload/operation/fromURLUpload) respectively.
+- For `Uploadcare`:
+  - `delete_file_group_with_files` method that not only deletes a file group but also deletes all the files within that group.
+- For `FileGroup`:
+  - `delete_with_files` method that not only deletes a file group, but also deletes all files in that group.
 
 ### Changed
 

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -329,11 +329,10 @@ Delete file groups::
     file_group: FileGroup = uploadcare.file_group('0513dda0-582f-447d-846f-096e5df9e2bb~2')
     file_group.delete()
 
-Please note that when you delete a file group, it doesn't automatically delete the files within it.
-To delete a file group and all the files it contains, you can use the following method::
+To delete a file group and all the files it contains::
 
     file_group: FileGroup = uploadcare.file_group('0513dda0-582f-447d-846f-096e5df9e2bb~2')
-    file_group.delete_with_files()
+    file_group.delete(delete_files=True)
 
 Create webhook
 --------------

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -329,6 +329,11 @@ Delete file groups::
     file_group: FileGroup = uploadcare.file_group('0513dda0-582f-447d-846f-096e5df9e2bb~2')
     file_group.delete()
 
+Please note that when you delete a file group, it doesn't automatically delete the files within it.
+To delete a file group and all the files it contains, you can use the following method::
+
+    file_group: FileGroup = uploadcare.file_group('0513dda0-582f-447d-846f-096e5df9e2bb~2')
+    file_group.delete_with_files()
 
 Create webhook
 --------------

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -601,7 +601,7 @@ class Uploadcare:
         for chunk in iterate_over_batches(uuids, self.batch_chunk_size):
             self.files_api.batch_store(chunk)
 
-    def delete_files(self, files: Iterable[Union[str, "File"]]) -> None:
+    def delete_files(self, files: Iterable[Union[str, UUID, "File"]]) -> None:
         """Deletes multiple files by requesting Uploadcare API.
 
         Usage example::

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -622,24 +622,6 @@ class Uploadcare:
         for chunk in iterate_over_batches(uuids, self.batch_chunk_size):
             self.files_api.batch_delete(chunk)
 
-    def delete_file_group_with_files(
-        self, group: Union[str, "FileGroup"]
-    ) -> None:
-        """Deletes file group and all its contents
-
-        Usage example::
-
-            >>> uploadcare = Uploadcare(public_key='<public-key>', secret_key='<secret-key>')
-            >>> uploadcare.delete_file_group_with_files("0513dda0-6666-447d-846f-096e5df9e2bb~2")
-
-        Args:
-            - group:
-                Group ID, CDN url or ``FileGroup`` instance.
-        """
-        if not isinstance(group, FileGroup):
-            group = self.file_group(group)
-        group.delete_with_files()
-
     def create_file_group(self, files: List[File]) -> FileGroup:
         """Creates file group and returns ``FileGroup`` instance.
 
@@ -684,7 +666,7 @@ class Uploadcare:
 
         Returns ``FileList`` instance providing iteration over all uploaded files.
 
-        Args:m
+        Args:
             - ``starting_point`` -- a starting point for filtering files.
               It is reflects a ``from`` parameter from REST API.
             - ``ordering`` -- a string with name of the field what must be used

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -622,6 +622,24 @@ class Uploadcare:
         for chunk in iterate_over_batches(uuids, self.batch_chunk_size):
             self.files_api.batch_delete(chunk)
 
+    def delete_file_group_with_files(
+        self, group: Union[str, "FileGroup"]
+    ) -> None:
+        """Deletes file group and all its contents
+
+        Usage example::
+
+            >>> uploadcare = Uploadcare(public_key='<public-key>', secret_key='<secret-key>')
+            >>> uploadcare.delete_file_group_with_files("0513dda0-6666-447d-846f-096e5df9e2bb~2")
+
+        Args:
+            - group:
+                Group ID, CDN url or ``FileGroup`` instance.
+        """
+        if not isinstance(group, FileGroup):
+            group = self.file_group(group)
+        group.delete_with_files()
+
     def create_file_group(self, files: List[File]) -> FileGroup:
         """Creates file group and returns ``FileGroup`` instance.
 

--- a/pyuploadcare/resources/file_group.py
+++ b/pyuploadcare/resources/file_group.py
@@ -223,3 +223,12 @@ class FileGroup:
 
         self._client.groups_api.delete(self.id)
         self._is_deleted = True
+
+    def delete_with_files(self):
+        """Delete group with all files in it.
+
+        Helper method, uses delete method added in API v. 0.7.0
+        """
+        self._client.delete_files(file_ for file_ in self)
+        self.update_info()
+        self.delete()

--- a/pyuploadcare/resources/file_group.py
+++ b/pyuploadcare/resources/file_group.py
@@ -213,22 +213,19 @@ class FileGroup:
         """
         return self._is_deleted
 
-    def delete(self):
+    def delete(self, delete_files: bool = False):
         """Delete group itself, left files unchanged
 
         Added in API v. 0.7.0
+
+        Args:
+            - ``delete_files`` -- ``True`` do also delete files in this group.
         """
         if self._is_deleted:
             return
 
+        if delete_files:
+            self._client.delete_files(file_ for file_ in self)
+
         self._client.groups_api.delete(self.id)
         self._is_deleted = True
-
-    def delete_with_files(self):
-        """Delete group with all files in it.
-
-        Helper method, uses delete method added in API v. 0.7.0
-        """
-        self._client.delete_files(file_ for file_ in self)
-        self.update_info()
-        self.delete()

--- a/pyuploadcare/resources/file_group.py
+++ b/pyuploadcare/resources/file_group.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional
 
 import dateutil.parser
 
@@ -13,6 +13,7 @@ from pyuploadcare.resources.utils import (
 
 if TYPE_CHECKING:
     from pyuploadcare.client import Uploadcare
+    from pyuploadcare.resources.file import File
 
 
 GROUP_ID_REGEX = re.compile(
@@ -27,7 +28,7 @@ GROUP_ID_REGEX = re.compile(
 )
 
 
-class FileGroup:
+class FileGroup(Iterable):
     """File Group resource for working with user-uploaded group of files.
 
     It can take group id or group CDN url::
@@ -91,6 +92,12 @@ class FileGroup:
             file_info = self.info["files"][key]
             if file_info is not None:
                 return self._client.file(file_info["uuid"], file_info)
+
+    def __iter__(self) -> Iterator["File"]:
+        for i in range(len(self)):
+            file_ = self[i]
+            if file_:
+                yield file_
 
     @property
     def cdn_url(self):

--- a/tests/functional/resources/cassettes/test_delete_file_group_with_files.yaml
+++ b/tests/functional/resources/cassettes/test_delete_file_group_with_files.yaml
@@ -1,0 +1,372 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/groups/2e481e82-2e39-41be-a5a2-23802c6e341c~2/
+  response:
+    content: '{"id":"2e481e82-2e39-41be-a5a2-23802c6e341c~2","datetime_created":"2023-07-02T20:09:42.633709Z","files_count":2,"cdn_url":"https://ucarecdn.com/2e481e82-2e39-41be-a5a2-23802c6e341c~2/","url":"https://api.uploadcare.com/groups/2e481e82-2e39-41be-a5a2-23802c6e341c~2/","files":[{"datetime_removed":null,"datetime_stored":"2023-07-02T19:57:29.447127Z","datetime_uploaded":"2023-07-02T19:57:29.355309Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":"https://ucarecdn.com/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/twoofthem.jpg","original_filename":"two-of-them.jpg","size":37202,"url":"https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/","uuid":"b47c1c0d-a47b-44ea-b185-9ca13d5758c1","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[144,144],"width":640,"format":"JPEG","height":588,"sequence":false,"color_mode":"RGB","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{},"default_effects":""},{"datetime_removed":null,"datetime_stored":"2023-07-02T19:57:35.164770Z","datetime_uploaded":"2023-07-02T19:57:35.083237Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":"https://ucarecdn.com/25671714-8642-4b02-9fbe-f5c35848c249/twentytwoofthem.png","original_filename":"twenty-two-of-them.png","size":368339,"url":"https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/","uuid":"25671714-8642-4b02-9fbe-f5c35848c249","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":800,"format":"PNG","height":788,"sequence":false,"color_mode":"P","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{},"default_effects":""}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1778'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - bd2324d6-08be-4a48-a9d8-8228ba68eca7
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/
+  response:
+    content: '{"datetime_removed":null,"datetime_stored":"2023-07-02T19:57:29.447127Z","datetime_uploaded":"2023-07-02T19:57:29.355309Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":"https://ucarecdn.com/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/twoofthem.jpg","original_filename":"two-of-them.jpg","size":37202,"url":"https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/","uuid":"b47c1c0d-a47b-44ea-b185-9ca13d5758c1","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[144,144],"width":640,"format":"JPEG","height":588,"sequence":false,"color_mode":"RGB","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '727'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - e75e8808-f43d-4e0f-a20e-833278641335
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/
+  response:
+    content: '{"datetime_removed":null,"datetime_stored":"2023-07-02T19:57:35.164770Z","datetime_uploaded":"2023-07-02T19:57:35.083237Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":"https://ucarecdn.com/25671714-8642-4b02-9fbe-f5c35848c249/twentytwoofthem.png","original_filename":"twenty-two-of-them.png","size":368339,"url":"https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/","uuid":"25671714-8642-4b02-9fbe-f5c35848c249","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":800,"format":"PNG","height":788,"sequence":false,"color_mode":"P","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '730'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 3ea25c36-6882-4563-b9e2-0f3898eec7f6
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '["b47c1c0d-a47b-44ea-b185-9ca13d5758c1", "25671714-8642-4b02-9fbe-f5c35848c249"]'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '80'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: DELETE
+    uri: https://api.uploadcare.com/files/storage/
+  response:
+    content: '{"status":"ok","result":[{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:29.355309Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":null,"original_filename":"two-of-them.jpg","size":37202,"url":"https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/","uuid":"b47c1c0d-a47b-44ea-b185-9ca13d5758c1","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[144,144],"width":640,"format":"JPEG","height":588,"sequence":false,"color_mode":"RGB","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}},{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:35.083237Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":null,"original_filename":"twenty-two-of-them.png","size":368339,"url":"https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/","uuid":"25671714-8642-4b02-9fbe-f5c35848c249","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":800,"format":"PNG","height":788,"sequence":false,"color_mode":"P","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}],"problems":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, OPTIONS, PUT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1355'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - a4a16944-ec81-4316-b2b2-0dc456fa7fcb
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/groups/2e481e82-2e39-41be-a5a2-23802c6e341c~2/
+  response:
+    content: '{"id":"2e481e82-2e39-41be-a5a2-23802c6e341c~2","datetime_created":"2023-07-02T20:09:42.633709Z","files_count":2,"cdn_url":"https://ucarecdn.com/2e481e82-2e39-41be-a5a2-23802c6e341c~2/","url":"https://api.uploadcare.com/groups/2e481e82-2e39-41be-a5a2-23802c6e341c~2/","files":[{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:29.355309Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":null,"original_filename":"two-of-them.jpg","size":37202,"url":"https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/","uuid":"b47c1c0d-a47b-44ea-b185-9ca13d5758c1","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[144,144],"width":640,"format":"JPEG","height":588,"sequence":false,"color_mode":"RGB","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{},"default_effects":""},{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:35.083237Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":null,"original_filename":"twenty-two-of-them.png","size":368339,"url":"https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/","uuid":"25671714-8642-4b02-9fbe-f5c35848c249","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":800,"format":"PNG","height":788,"sequence":false,"color_mode":"P","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{},"default_effects":""}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1634'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - d763898c-ae27-4941-a3f0-858113f091ef
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: DELETE
+    uri: https://api.uploadcare.com/groups/2e481e82-2e39-41be-a5a2-23802c6e341c~2/
+  response:
+    content: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Sun, 02 Jul 2023 20:13:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 03d24558-a8e4-47ed-b622-768e0c9ae50b
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 204
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/
+  response:
+    content: '{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:29.355309Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":null,"original_filename":"two-of-them.jpg","size":37202,"url":"https://api.uploadcare.com/files/b47c1c0d-a47b-44ea-b185-9ca13d5758c1/","uuid":"b47c1c0d-a47b-44ea-b185-9ca13d5758c1","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[144,144],"width":640,"format":"JPEG","height":588,"sequence":false,"color_mode":"RGB","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '658'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - f2068b1f-2fce-48cc-8296-800d1eec7f59
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.0.0/d3d50ff74f71ea573419 (CPython/3.11.3)
+    method: GET
+    uri: https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/
+  response:
+    content: '{"datetime_removed":"2023-07-02T20:13:05.565949Z","datetime_stored":null,"datetime_uploaded":"2023-07-02T19:57:35.083237Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":null,"original_filename":"twenty-two-of-them.png","size":368339,"url":"https://api.uploadcare.com/files/25671714-8642-4b02-9fbe-f5c35848c249/","uuid":"25671714-8642-4b02-9fbe-f5c35848c249","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":800,"format":"PNG","height":788,"sequence":false,"color_mode":"P","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '655'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 02 Jul 2023 20:13:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 9ce95907-6429-4515-9aeb-cc72355b8f4b
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -257,6 +257,22 @@ def test_create_file_group(uploadcare):
 
 
 @pytest.mark.vcr
+def test_delete_file_group_with_files(uploadcare):
+    group = uploadcare.file_group("2e481e82-2e39-41be-a5a2-23802c6e341c~2")
+    assert not group.is_deleted
+    for file in group:
+        file.update_info()
+        assert not file.is_removed
+
+    uploadcare.delete_file_group_with_files(group)
+
+    assert group.is_deleted
+    for file in group:
+        file.update_info()
+        assert file.is_removed
+
+
+@pytest.mark.vcr
 def test_get_file_group(uploadcare):
     group = uploadcare.file_group("d496a4df-0b36-4281-8156-268ae9524d4a~1")
     assert group.info

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -264,7 +264,7 @@ def test_delete_file_group_with_files(uploadcare):
         file.update_info()
         assert not file.is_removed
 
-    uploadcare.delete_file_group_with_files(group)
+    group.delete(delete_files=True)
 
     assert group.is_deleted
     for file in group:


### PR DESCRIPTION
## Description

Related issue: #198 

> Motivated by https://github.com/uploadcare/pyuploadcare/issues/196
> 
> Groups are unremovable. But the files in the group are. Some times user has a need to remove all files in a group and currently, the only way to do this is to iterate over files and use delete or batch delete method.
> This makes code more complex and, potentially, increases number of requests to achieve the goal.
> 
> p.s.: Also, consider adding this as a core REST API functionality?

Changing the Uploadcare API is out of scope of this project. Helpers methods, however, have been implemented.

Example usage for `Uploadcare`:

```
uploadcare.delete_file_group_with_files("2e481e82-2e39-41be-a5a2-23802c6e341c~2") 
```

Example usage for `FileGroup`:

```
group = uploadcare.file_group("2e481e82-2e39-41be-a5a2-23802c6e341c~2")
group.delete_with_files()
```


## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
