### PR TITLE
Fix ValidationError that occurred when requesting file information for specific video files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1](https://github.com/uploadcare/pyuploadcare/compare/v4.1.0...v4.1.1) - 2023-09-01
+
+### Fixed
+
+- Resolved a `ValidationError` that occurred when requesting file information for specific video files.
+
 ## [4.1.0](https://github.com/uploadcare/pyuploadcare/compare/v4.0.0...v4.1.0) - 2023-07-18
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.1](https://github.com/uploadcare/pyuploadcare/compare/v4.1.0...v4.1.1) - 2023-09-01
+## [4.1.1](https://github.com/uploadcare/pyuploadcare/compare/v4.1.0...v4.1.1) - 2023-09-04
 
 ### Fixed
 

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -75,14 +75,14 @@ class VideoStreamInfo(Entity):
     height: Decimal
     width: Decimal
     frame_rate: float
-    bitrate: Decimal
-    codec: str
+    bitrate: Optional[Decimal]
+    codec: Optional[str]
 
 
 class VideoInfo(Entity):
-    duration: Decimal
+    duration: Optional[Decimal]
     format: str
-    bitrate: Decimal
+    bitrate: Optional[Decimal]
     audio: List[AudioStreamInfo]
     video: List[VideoStreamInfo]
 


### PR DESCRIPTION
API spec says that these fields are nullable, but pyuploadcare expected them to have values:

- `VideoStreamInfo#bitrate`
- `VideoStreamInfo#codec`
- `VideoInfo#duration`
- `VideoInfo#bitrate`

That sometimes led to errors like this:

```
pydantic.error_wrappers.ValidationError: 1 validation error for ParsingModel[FileListResponse]
__root__ -> results -> 79 -> content_info -> video -> video -> 0 -> bitrate
none is not an allowed value (type=type_error.none.not_allowed)
```