### PR TITLE
Fixed: Incorrect expiration time for signed uploads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.2](https://github.com/uploadcare/pyuploadcare/compare/v4.1.1...v4.1.2) - 2023-09-08
+
+### Fixed
+
+- Incorrect expiration time was calculated for signed uploads causing the `AuthenticationError: Expired signature` exception.
+
 ## [4.1.1](https://github.com/uploadcare/pyuploadcare/compare/v4.1.0...v4.1.1) - 2023-09-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyuploadcare"
-version = "4.1.1"
+version = "4.1.2"
 description = "Python library for Uploadcare.com"
 authors = ["Uploadcare Inc <hello@uploadcare.com>"]
 readme = "README.md"

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-__version__ = "4.1.1"
+__version__ = "4.1.2"
 
 from pyuploadcare.resources.file import File  # noqa: F401
 from pyuploadcare.resources.file_group import FileGroup  # noqa: F401

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -1,5 +1,6 @@
 import os
 import socket
+from time import time
 from typing import (
     IO,
     Any,
@@ -373,7 +374,7 @@ class Uploadcare:
             files=files,
             store=self._format_store(store),
             secure_upload=self.signed_uploads,
-            expire=self.signed_uploads_ttl,
+            expire=int(time()) + self.signed_uploads_ttl,
             common_metadata=common_metadata,
         )
         ucare_files = [self.file(response[file_name]) for file_name in files]
@@ -425,7 +426,7 @@ class Uploadcare:
             content_type=mime_type,
             store=self._format_store(store),
             secure_upload=self.signed_uploads,
-            expire=self.signed_uploads_ttl,
+            expire=int(time()) + self.signed_uploads_ttl,
             metadata=metadata,
         )
 
@@ -495,7 +496,7 @@ class Uploadcare:
             filename=filename,
             metadata=metadata,
             secure_upload=self.signed_uploads,
-            expire=self.signed_uploads_ttl,
+            expire=int(time()) + self.signed_uploads_ttl,
             check_duplicates=check_duplicates,
             save_duplicates=save_duplicates,
         )
@@ -647,7 +648,7 @@ class Uploadcare:
         group_info = self.upload_api.create_group(
             files=file_urls,
             secure_upload=self.signed_uploads,
-            expire=self.signed_uploads_ttl,
+            expire=int(time()) + self.signed_uploads_ttl,
         )
 
         group = self.file_group(group_info["id"], group_info)


### PR DESCRIPTION
Incorrect expiration time was calculated for signed uploads causing the `AuthenticationError: Expired signature` exception.

See the Telegram chat for more details.
