### PR TITLE
secure_uploads settings for Django

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,28 +12,29 @@ Summary of this update:
 
 1. Added support for the `save_in_group` parameter in [multipage conversion](https://uploadcare.com/docs/transformations/document-conversion/#multipage-conversion);
 2. Implemented the [AWS Rekognition Moderation](https://uploadcare.com/docs/unsafe-content/) addon API;
-3. Various bug fixes.
+3. Added `signed_uploads` setting for Django projects;
+4. Various bug fixes.
 
 There are no breaking changes in this release.
 
 ### Added
 
 - For `File`:
-  - Added `save_in_group` parameter to `convert` and `convert_document` methods. It defaults to `False`. When set to `True`, multi-page documents will additionally be saved as a file group.
-  - Added `get_converted_document_group` method. It returns a `FileGroup` instance for converted multi-page documents.
+  - Added the `save_in_group` parameter to the `convert` and `convert_document` methods. It defaults to `False`. When set to `True`, multi-page documents will additionally be saved as a file group.
+  - Added the `get_converted_document_group` method. It returns a `FileGroup` instance for converted multi-page documents.
 
 - For `DocumentConvertAPI`:
-  - Added `retrieve` method which corresponds to the [`GET /convert/document/:uuid/`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo) API endpoint.
+  - Added the `retrieve` method, which corresponds to the [`GET /convert/document/:uuid/`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo) API endpoint.
 
 - For `Uploadcare`:
   - Added type for the `event` parameter of the `create_webhook` and `update_webhook` methods.
-  - added `generate_upload_signature` method. This shortcut could be useful for signed uploads from your website's frontend where the signature needs to be passed outside of your website's Python part (e.g. for the uploading widget).
+  - Added the `generate_upload_signature` method. This shortcut could be useful for signed uploads from your website's frontend, where the signature needs to be passed outside of your website's Python part (e.g., for the uploading widget).
 
 - For `AddonsAPI` / `AddonLabels`:
   - Added support for the [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
 
 - For Django integration:
-  - added `signed_uploads` setting for Django projects. When enabled, this setting exposes the generated signature to the uploading widget.
+  - Added the `signed_uploads` setting for Django projects. When enabled, this setting exposes the generated signature to the uploading widget.
 
 ### Fixed
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.5](https://github.com/uploadcare/pyuploadcare/compare/v4.1.4...v4.1.5) - 2023-10-30
+
+### Added
+
+- For `Uploadcare`:
+  - added `generate_upload_signature` method. This shortcut could be useful for signed uploads from your website's frontend where the signature needs to be passed outside of your site's Python part (e.g. for an upload widget).
+
+- For Django integration:
+  - added `signed_uploads` setting for Django projects. When enabled, this setting exposes the generated signature to the upload widget.
+
 ## [4.1.3](https://github.com/uploadcare/pyuploadcare/compare/v4.1.2...v4.1.3) - 2023-10-05
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,10 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - For `Uploadcare`:
-  - added `generate_upload_signature` method. This shortcut could be useful for signed uploads from your website's frontend where the signature needs to be passed outside of your site's Python part (e.g. for an upload widget).
+  - added `generate_upload_signature` method. This shortcut could be useful for signed uploads from your website's frontend where the signature needs to be passed outside of your website's Python part (e.g. for the uploading widget).
 
 - For Django integration:
-  - added `signed_uploads` setting for Django projects. When enabled, this setting exposes the generated signature to the upload widget.
+  - added `signed_uploads` setting for Django projects. When enabled, this setting exposes the generated signature to the uploading widget.
 
 ## [4.1.3](https://github.com/uploadcare/pyuploadcare/compare/v4.1.2...v4.1.3) - 2023-10-05
 

--- a/docs/django-widget.rst
+++ b/docs/django-widget.rst
@@ -59,9 +59,7 @@ widget url:
         'upload_base_url': 'http://path.to/your/upload/handler',
     }
 
-If you have signed uploads enabled in your Uploadcare project, widget-based uploads will fail unless you enable the ``signed_uploads`` setting in your Django project.
-
-Note that in this case, the benefits of signed uploads are essentially negated for user uploads. So enabling this feature is only feasible if, for example, files are only uploaded via the admin interface.
+If you have signed uploads enabled in your Uploadcare project, widget-based uploads will fail unless you enable the ``signed_uploads`` setting in your Django project::
 
 .. code-block:: python
 

--- a/docs/django-widget.rst
+++ b/docs/django-widget.rst
@@ -56,8 +56,20 @@ widget url:
 
     UPLOADCARE = {
         # ...
-        'upload_base_url' = 'http://path.to/your/upload/handler',
+        'upload_base_url': 'http://path.to/your/upload/handler',
     }
+
+If you have signed uploads enabled in your Uploadcare project, widget-based uploads will fail unless you enable the ``signed_uploads`` setting in your Django project.
+
+Note that in this case, the benefits of signed uploads are essentially negated for user uploads. So enabling this feature is only feasible if, for example, files are only uploaded via the admin interface.
+
+.. code-block:: python
+
+    UPLOADCARE = {
+        # ...,
+        'signed_uploads': True,
+    }
+
 
 .. _django-widget-models-ref:
 

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -246,7 +246,7 @@ class UploadAPI(API):
     resource_type = "base"
 
     @staticmethod
-    def _generate_secure_signature(secret: str, expire: int):
+    def generate_secure_signature(secret: str, expire: int):
         return hmac.new(
             secret.encode("utf-8"), str(expire).encode("utf-8"), hashlib.sha256
         ).hexdigest()
@@ -282,7 +282,7 @@ class UploadAPI(API):
                 expire = int(time()) + self.signed_uploads_ttl
             data["expire"] = str(expire)
 
-            signature = self._generate_secure_signature(secret_key, expire)  # type: ignore
+            signature = self.generate_secure_signature(secret_key, expire)  # type: ignore
             data["signature"] = signature
 
         url = self._build_url()
@@ -321,7 +321,7 @@ class UploadAPI(API):
             )
 
             data["expire"] = str(expire)
-            data["signature"] = self._generate_secure_signature(
+            data["signature"] = self.generate_secure_signature(
                 self.secret_key, expire  # type: ignore
             )
 
@@ -377,7 +377,7 @@ class UploadAPI(API):
             )
 
             data["expire"] = str(expire)
-            data["signature"] = self._generate_secure_signature(
+            data["signature"] = self.generate_secure_signature(
                 self.secret_key, expire  # type: ignore
             )
 
@@ -434,7 +434,7 @@ class UploadAPI(API):
             )
 
             data["expire"] = str(expire)
-            data["signature"] = self._generate_secure_signature(
+            data["signature"] = self.generate_secure_signature(
                 self.secret_key, expire  # type: ignore
             )
 

--- a/pyuploadcare/client.py
+++ b/pyuploadcare/client.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Type,
     Union,
 )
@@ -813,6 +814,16 @@ class Uploadcare:
         """Get info about account project."""
 
         return self.project_api.retrieve()
+
+    def generate_upload_signature(self) -> Tuple[int, str]:
+        """Expiration and signature for signed uploads."""
+        if not self.secret_key:
+            raise ValueError("secret_key is required")
+        expire = int(time()) + self.signed_uploads_ttl
+        signature = self.upload_api.generate_secure_signature(
+            self.secret_key, expire
+        )
+        return expire, signature
 
     def generate_secure_url(self, uuid: Union[str, UUID]) -> str:
         """Generate authenticated URL."""

--- a/pyuploadcare/dj/conf.py
+++ b/pyuploadcare/dj/conf.py
@@ -24,6 +24,7 @@ user_agent_extension = "Django/{0}; PyUploadcare-Django/{1}".format(
 
 cdn_base = settings.UPLOADCARE.get("cdn_base")
 
+signed_uploads = settings.UPLOADCARE.get("signed_uploads", False)
 
 widget_version = settings.UPLOADCARE.get("widget_version", "3.x")
 widget_build = settings.UPLOADCARE.get(

--- a/pyuploadcare/dj/forms.py
+++ b/pyuploadcare/dj/forms.py
@@ -56,9 +56,9 @@ class FileField(Field):
     _client: Uploadcare
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
         self._client = get_uploadcare_client()
+
+        super().__init__(*args, **kwargs)
 
     def to_python(self, value):
         if value is None or value == "":
@@ -73,6 +73,10 @@ class FileField(Field):
         attrs = {}
         if not self.required:
             attrs["data-clearable"] = ""
+        if dj_conf.signed_uploads:
+            expire, signature = self._client.generate_upload_signature()
+            attrs["data-secure-expire"] = expire
+            attrs["data-secure-signature"] = signature
         return attrs
 
 

--- a/tests/functional/api/test_upload_api.py
+++ b/tests/functional/api/test_upload_api.py
@@ -54,3 +54,13 @@ def test_multipart_upload(big_file, uploadcare):
 
     response = uploadcare.upload_api.multipart_complete(multipart_uuid)
     assert "file_id" in response
+
+
+@pytest.mark.freeze_time("2023-10-27")
+def test_generate_upload_signature(uploadcare):
+    expire, signature = uploadcare.generate_upload_signature()
+    assert expire == 1698364860
+    assert (
+        signature
+        == "bf659caf5e081da589634770a84494fdb310d117be6f3f7b8e9842abf2997695"
+    )


### PR DESCRIPTION
Related issue #262 

Enabling `secure_uploads` will expose signatures to all `FileField`s, not only limited to Django admin. While this may be desired in some cases, it also poses a security risk for websites with user uploads. This has been highlighted in the documentation, but it may need to be rephrased somehow (@rsedykh?).