### PR TITLE
Multipage conversion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.2.0](https://github.com/uploadcare/pyuploadcare/compare/v4.1.3...v4.2.0) - 2023-11-16
 
-In this update:
+Summary of this update:
 
 1. Added support for the `save_in_group` parameter in [multipage conversion](https://uploadcare.com/docs/transformations/document-conversion/#multipage-conversion);
 2. Implemented the [AWS Rekognition Moderation](https://uploadcare.com/docs/unsafe-content/) addon API;
@@ -17,22 +17,22 @@ In this update:
 ### Added
 
 - For `File`:
-  - added `save_in_group` parameter to `convert` and `convert_document` methods. It defaults to `False`. When set to `True`, multi-page documents additionally will be saved as a file group.
-  - added `get_converted_document_group` method. It returns a `FileGroup` instance for converted multi-page documents.
+  - Added `save_in_group` parameter to `convert` and `convert_document` methods. It defaults to `False`. When set to `True`, multi-page documents will additionally be saved as a file group.
+  - Added `get_converted_document_group` method. It returns a `FileGroup` instance for converted multi-page documents.
 
 - For `DocumentConvertAPI`:
-  - added `retrieve` method which corresponds to [`GET /convert/document/:uuid/`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo) API endpoint.
+  - Added `retrieve` method which corresponds to the [`GET /convert/document/:uuid/`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo) API endpoint.
 
 - For `Uploadcare`:
-  - Added type for parameter `event` of `create_webhook` and `update_webhook` methods.
+  - Added type for the `event` parameter of the `create_webhook` and `update_webhook` methods.
 
 - For `AddonsAPI` / `AddonLabels`:
-  - Added support for [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
+  - Added support for the [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
 
 ### Fixed
 
 - For `AddonsAPI` / `AddonExecutionParams`:
-  - Fixed the issue where calling `execute` and `status` with `AddonLabels`'s attributes (such as `AddonLabels.REMOVE_BG`) for `addon_name` would result in a _404 Not Found_ error.
+  - Fixed an issue where calling `execute` and `status` with `AddonLabels`'s attributes (such as `AddonLabels.REMOVE_BG`) for the `addon_name` would result in a _404 Not Found_ error.
   - Fixed `ValidationError` when constructing `AddonClamAVExecutionParams` or `AddonRemoveBGExecutionParams` with omitted optional parameters.
 
 ## [4.1.3](https://github.com/uploadcare/pyuploadcare/compare/v4.1.2...v4.1.3) - 2023-10-05

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,18 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.6](https://github.com/uploadcare/pyuploadcare/compare/v4.1.5...v4.1.6) - soon
+
+### Added
+
+- For `File`:
+  - added `save_in_group` parameter to `convert` and `convert_document` methods. It defaults to `False`. When set to `True`, multi-page documents additionally will be saved as a file group.
+  - added `get_converted_document_group` method. It returns a `FileGroup` instance for converted multi-page documents.
+
+- For `DocumentConvertAPI`:
+  - added `retrieve` method which corresponds to [`GET /convert/document/:uuid/`](https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Conversion/operation/documentConvertInfo) API endpoint.
+
+
 ## [4.1.3](https://github.com/uploadcare/pyuploadcare/compare/v4.1.2...v4.1.3) - 2023-10-05
 
 ### Added

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -157,6 +157,13 @@ or create an image of a particular page (if using image format)::
     transformation = DocumentTransformation().format(DocumentFormat.png).page(1)
     converted_file: File = file.convert(transformation)
 
+or create a file group of converted pages of multipage document::
+
+    file = uploadcare.file('0e1cac48-1296-417f-9e7f-9bf13e330dcf')
+    transformation = DocumentTransformation().format(DocumentFormat.jpg)
+    file.convert(transformation, save_in_group=True)
+    converted_group: FileGroup = file.get_converted_document_group(DocumentFormat.jpg)
+
 or you can use API directly to convert single or multiple files::
 
     transformation = DocumentTransformation().format(DocumentFormat.pdf)

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -157,7 +157,7 @@ or create an image of a particular page (if using image format)::
     transformation = DocumentTransformation().format(DocumentFormat.png).page(1)
     converted_file: File = file.convert(transformation)
 
-or create a file group of converted pages of multipage document::
+or create a file group of converted pages of a multipage document::
 
     file = uploadcare.file('0e1cac48-1296-417f-9e7f-9bf13e330dcf')
     transformation = DocumentTransformation().format(DocumentFormat.jpg)

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -183,9 +183,11 @@ class DocumentConvertAPI(API, RetrieveMixin):
     }
 
     def retrieve(
-        self, file_uuid: Union[UUID, str, UUIDEntity]
+        self,
+        resource_uuid: Optional[Union[UUID, str, UUIDEntity]] = None,
+        include_appdata: bool = False,
     ) -> entities.DocumentConvertFormatInfo:
-        response = super().retrieve(file_uuid)
+        response = super().retrieve(resource_uuid)
         return cast(entities.DocumentConvertFormatInfo, response)
 
     def convert(

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -185,14 +185,19 @@ class DocumentConvertAPI(API):
         self,
         paths: List[str],
         store: Optional[bool] = None,
+        save_in_group: bool = False,
     ) -> responses.DocumentConvertResponse:
         url = self._build_url()
 
         data = {
             "paths": paths,
         }
+
         if isinstance(store, bool):
             data["store"] = str(store).lower()  # type: ignore
+
+        if save_in_group:
+            data["save_in_group"] = "1"  # type: ignore
 
         response_class = self._get_response_class("convert")
         document = self._client.post(url, json=data).json()

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -172,14 +172,21 @@ class WebhooksAPI(API, CreateMixin, ListMixin, UpdateMixin, DeleteMixin):
             self._process_exceptions(request_error)
 
 
-class DocumentConvertAPI(API):
+class DocumentConvertAPI(API, RetrieveMixin):
     resource_type = "convert/document"
     entity_class = entities.DocumentConvertInfo
 
     response_classes = {
+        "retrieve": entities.DocumentConvertFormatInfo,
         "convert": responses.DocumentConvertResponse,
         "status": entities.DocumentConvertStatus,
     }
+
+    def retrieve(
+        self, file_uuid: Union[UUID, str, UUIDEntity]
+    ) -> entities.DocumentConvertFormatInfo:
+        response = super().retrieve(file_uuid)
+        return cast(entities.DocumentConvertFormatInfo, response)
 
     def convert(
         self,

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -7,8 +7,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConstrainedStr, EmailStr, Field, PrivateAttr
 
-from pyuploadcare.transformations.document import DocumentFormat
-
 from .metadata import META_KEY_MAX_LEN, META_KEY_PATTERN, META_VALUE_MAX_LEN
 
 

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConstrainedStr, EmailStr, Field, PrivateAttr
 
+from pyuploadcare.transformations.document import DocumentFormat
+
 from .metadata import META_KEY_MAX_LEN, META_KEY_PATTERN, META_VALUE_MAX_LEN
 
 
@@ -248,11 +250,19 @@ class DocumentConvertStatus(Entity):
     result: DocumentConvertShortInfo
 
 
-class DocumentConvertRetrieveInfo(Entity):
-    ...  # TODO
-    error: Any
-    format: Any
-    converted_groups: Any
+class DocumentConvertConversionFormat(Entity):
+    name: str
+
+
+class DocumentConvertFormat(Entity):
+    name: str
+    conversion_formats: List[DocumentConvertConversionFormat]
+    converted_groups: Dict[str, str]
+
+
+class DocumentConvertFormatInfo(Entity):
+    error: Optional[str]
+    format: DocumentConvertFormat
 
 
 class VideoConvertShortInfo(Entity):

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -248,6 +248,13 @@ class DocumentConvertStatus(Entity):
     result: DocumentConvertShortInfo
 
 
+class DocumentConvertRetrieveInfo(Entity):
+    ...  # TODO
+    error: Any
+    format: Any
+    converted_groups: Any
+
+
 class VideoConvertShortInfo(Entity):
     uuid: UUID
     thumbnails_group_uuid: str

--- a/pyuploadcare/resources/file.py
+++ b/pyuploadcare/resources/file.py
@@ -5,14 +5,22 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 from uuid import UUID
 
-from pyuploadcare.api.entities import DocumentConvertInfo, VideoConvertInfo
+from pyuploadcare.api.entities import (
+    DocumentConvertFormatInfo,
+    DocumentConvertInfo,
+    VideoConvertInfo,
+)
 from pyuploadcare.exceptions import (
     InvalidParamError,
     InvalidRequestError,
     TimeoutError,
     UploadError,
 )
-from pyuploadcare.transformations.document import DocumentTransformation
+from pyuploadcare.resources.file_group import FileGroup
+from pyuploadcare.transformations.document import (
+    DocumentFormat,
+    DocumentTransformation,
+)
 from pyuploadcare.transformations.image import ImageTransformation
 from pyuploadcare.transformations.video import VideoTransformation
 
@@ -479,6 +487,15 @@ class File:
         conversion_info: DocumentConvertInfo = response.result[0]  # type: ignore
         new_uuid = conversion_info.uuid
         return File(new_uuid, self._client)
+
+    def get_converted_document_group(
+        self, format: DocumentFormat
+    ) -> FileGroup:
+        response: DocumentConvertFormatInfo = (
+            self._client.document_convert_api.retrieve(self.uuid)
+        )
+        group_id = response.format.converted_groups[format]
+        return self._client.file_group(group_id)
 
 
 class FileFromUrl:

--- a/pyuploadcare/resources/file.py
+++ b/pyuploadcare/resources/file.py
@@ -371,6 +371,7 @@ class File:
         self,
         transformation: Union[VideoTransformation, DocumentTransformation],
         store: Optional[bool] = None,
+        save_in_group: bool = False,
     ) -> "File":
         """Convert video or document and return converted file.
 
@@ -396,18 +397,26 @@ class File:
             >>> converted_file: File = file.convert(transformation)
 
         Arguments:
-            - transformation (Union[VideoTransformation, Documenttransformation]): transformation
+            - transformation (Union[VideoTransformation, DocumentTransformation]): transformation
                 path builder with configured parameters.
                 Depending on type video or document conversion will be performed.
             - store (Optional[bool]): Should the file be automatically stored. Defaults to None.
                 - False - do not store file
                 - True - store file
                 - None - use project settings
+            - save_in_group (bool): Should pages of a multipage document be stored as a file group.
+                Available only for documents. Defaults to False.
         """
         if isinstance(transformation, VideoTransformation):
+            if save_in_group:
+                raise ValueError(
+                    "Multipage conversion is available only for documents."
+                )
             return self.convert_video(transformation, store=store)
         elif isinstance(transformation, DocumentTransformation):
-            return self.convert_document(transformation, store=store)
+            return self.convert_document(
+                transformation, store=store, save_in_group=save_in_group
+            )
 
         raise ValueError(f"Unsupported transformation: {transformation}")
 
@@ -445,6 +454,7 @@ class File:
         self,
         transformation: Union[str, DocumentTransformation],
         store: Optional[bool] = None,
+        save_in_group: bool = False,
     ) -> "File":
         """Convert document and return converted file instance.
 
@@ -459,7 +469,9 @@ class File:
         transformation = DocumentTransformation(transformation)
         path = transformation.path(self.uuid)
         response = self._client.document_convert_api.convert(
-            paths=[path], store=store
+            paths=[path],
+            store=store,
+            save_in_group=save_in_group,
         )
         if response.problems:
             raise InvalidRequestError(str(response.problems))

--- a/pyuploadcare/ucare_cli/commands/convert_document.py
+++ b/pyuploadcare/ucare_cli/commands/convert_document.py
@@ -23,6 +23,13 @@ def register_arguments(subparsers):
         type=int,
     )
     subparser.add_argument(
+        "--save-in-group",
+        action="store_true",
+        default=False,
+        dest="save_in_group",
+        help="Save pages of a multipage document to a group",
+    )
+    subparser.add_argument(
         "--store",
         action="store_true",
         default=False,
@@ -44,8 +51,12 @@ def convert_document(arg_namespace, client: Uploadcare) -> None:
         transformation.format(arg_namespace.page)
 
     kwargs = {}
+
     if arg_namespace.store:
         kwargs["store"] = True
+
+    if arg_namespace.save_in_group:
+        kwargs["save_in_group"] = True
 
     converted_file = file.convert_document(transformation, **kwargs)
 

--- a/tests/functional/api/cassettes/test_convert_document_get_group_info.yaml
+++ b/tests/functional/api/cassettes/test_convert_document_get_group_info.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/convert/document/da288a95-3029-4044-b902-5107e8579c5c/
+  response:
+    content: '{"error":null,"format":{"name":"pdf","conversion_formats":[{"name":"bmp"},{"name":"csv"},{"name":"doc"},{"name":"docx"},{"name":"dwg"},{"name":"dxf"},{"name":"enhanced.jpg"},{"name":"epub"},{"name":"fb2"},{"name":"gif"},{"name":"html"},{"name":"html5"},{"name":"html5-1page"},{"name":"htmlz"},{"name":"jpg"},{"name":"lit"},{"name":"lrf"},{"name":"md"},{"name":"mobi"},{"name":"mp3"},{"name":"pcx"},{"name":"pdb"},{"name":"png"},{"name":"ppt"},{"name":"pptx"},{"name":"prc"},{"name":"ps"},{"name":"rb"},{"name":"rtf"},{"name":"snb"},{"name":"svg"},{"name":"tcr"},{"name":"thumbnail"},{"name":"tiff"},{"name":"txt"},{"name":"txtz"},{"name":"xls"},{"name":"xlsx"}],"converted_groups":{"jpg":"f56f1e80-31f8-426e-9213-690861252070~4"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '731'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Fri, 03 Nov 2023 22:14:18 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 463f9b14-1110-4b92-91fc-282679346573
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_convert_document_with_save_in_group.yaml
+++ b/tests/functional/api/cassettes/test_convert_document_with_save_in_group.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"paths": ["da288a95-3029-4044-b902-5107e8579c5c/document/-/format/jpg/"],
+      "save_in_group": "1"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '96'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/convert/document/
+  response:
+    content: '{"result": [{"original_source": "da288a95-3029-4044-b902-5107e8579c5c/document/-/format/jpg/",
+      "token": 39498673, "uuid": "482e9d07-08ee-4c6d-875f-216aabc561c9"}], "problems":
+      {}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 22:16:05 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 7cb15931-717a-4b31-8cf7-909d7b4fe7c2
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/convert/document/status/39498673/
+  response:
+    content: '{"error":null,"status":"pending","result":{"uuid":"482e9d07-08ee-4c6d-875f-216aabc561c9"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Thu, 02 Nov 2023 22:16:05 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 6f4fa049-5337-43b9-bdec-a5cc77793eb9
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/test_document_convert_api.py
+++ b/tests/functional/api/test_document_convert_api.py
@@ -23,3 +23,24 @@ def test_convert_document(uploadcare):
     )
 
     assert document_convert_status.result.uuid
+
+
+@pytest.mark.vcr
+def test_convert_document_with_save_in_group(uploadcare):
+    transformation = DocumentTransformation().format(DocumentFormat.jpg)
+
+    path = transformation.path("da288a95-3029-4044-b902-5107e8579c5c")
+
+    response = uploadcare.document_convert_api.convert(
+        [path], save_in_group=True
+    )
+
+    assert not response.problems
+
+    document_convert_info = response.result[0]
+
+    document_convert_status = uploadcare.document_convert_api.status(
+        document_convert_info.token
+    )
+
+    assert document_convert_status.result.uuid

--- a/tests/functional/api/test_document_convert_api.py
+++ b/tests/functional/api/test_document_convert_api.py
@@ -44,3 +44,11 @@ def test_convert_document_with_save_in_group(uploadcare):
     )
 
     assert document_convert_status.result.uuid
+
+
+@pytest.mark.vcr
+def test_convert_document_get_group_info(uploadcare):
+    response = uploadcare.document_convert_api.retrieve(
+        "da288a95-3029-4044-b902-5107e8579c5c"
+    )
+    assert "~" in response.format.converted_groups[DocumentFormat.jpg]

--- a/tests/functional/resources/cassettes/test_file_convert_document_with_save_in_group.yaml
+++ b/tests/functional/resources/cassettes/test_file_convert_document_with_save_in_group.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"paths": ["da288a95-3029-4044-b902-5107e8579c5c/document/-/format/jpg/"],
+      "save_in_group": "1"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '96'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/convert/document/
+  response:
+    content: '{"result": [{"original_source": "da288a95-3029-4044-b902-5107e8579c5c/document/-/format/jpg/",
+      "token": 39498616, "uuid": "dee1e90f-f663-4a0a-8aae-be2e50b8c137"}], "problems":
+      {}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 02 Nov 2023 22:14:01 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - de637ca5-15b1-4e69-b76a-3411db7238b3
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/files/dee1e90f-f663-4a0a-8aae-be2e50b8c137/
+  response:
+    content: '{"datetime_removed":null,"datetime_stored":"2023-11-02T22:14:01.799914Z","datetime_uploaded":"2023-11-02T22:14:01.799914Z","is_image":null,"is_ready":false,"mime_type":"","original_file_url":null,"original_filename":"","size":0,"url":"https://api.uploadcare.com/files/dee1e90f-f663-4a0a-8aae-be2e50b8c137/","uuid":"dee1e90f-f663-4a0a-8aae-be2e50b8c137","variations":null,"content_info":null,"metadata":{}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '405'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Thu, 02 Nov 2023 22:14:02 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 836e1465-9be1-405c-a88b-33484e7cd169
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/resources/cassettes/test_file_get_converted_document_group.yaml
+++ b/tests/functional/resources/cassettes/test_file_get_converted_document_group.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/convert/document/da288a95-3029-4044-b902-5107e8579c5c/
+  response:
+    content: '{"error":null,"format":{"name":"pdf","conversion_formats":[{"name":"bmp"},{"name":"csv"},{"name":"doc"},{"name":"docx"},{"name":"dwg"},{"name":"dxf"},{"name":"enhanced.jpg"},{"name":"epub"},{"name":"fb2"},{"name":"gif"},{"name":"html"},{"name":"html5"},{"name":"html5-1page"},{"name":"htmlz"},{"name":"jpg"},{"name":"lit"},{"name":"lrf"},{"name":"md"},{"name":"mobi"},{"name":"mp3"},{"name":"pcx"},{"name":"pdb"},{"name":"png"},{"name":"ppt"},{"name":"pptx"},{"name":"prc"},{"name":"ps"},{"name":"rb"},{"name":"rtf"},{"name":"snb"},{"name":"svg"},{"name":"tcr"},{"name":"thumbnail"},{"name":"tiff"},{"name":"txt"},{"name":"txtz"},{"name":"xls"},{"name":"xlsx"}],"converted_groups":{"jpg":"f56f1e80-31f8-426e-9213-690861252070~4"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '731'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Fri, 03 Nov 2023 22:32:16 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 09cfbddf-b19d-44c4-aa41-f93b9fcb21be
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -219,6 +219,14 @@ def test_file_convert_document(uploadcare):
 
 
 @pytest.mark.vcr
+def test_file_convert_document_with_save_in_group(uploadcare):
+    file = uploadcare.file("da288a95-3029-4044-b902-5107e8579c5c")
+    transformation = DocumentTransformation().format(DocumentFormat.jpg)
+    converted_file = file.convert(transformation, save_in_group=True)
+    assert not converted_file.is_ready
+
+
+@pytest.mark.vcr
 def test_file_info_has_new_structure(uploadcare):
     """
     Test new structure of response since API v0.7

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -227,6 +227,14 @@ def test_file_convert_document_with_save_in_group(uploadcare):
 
 
 @pytest.mark.vcr
+def test_file_get_converted_document_group(uploadcare):
+    file = uploadcare.file("da288a95-3029-4044-b902-5107e8579c5c")
+    group = file.get_converted_document_group(DocumentFormat.jpg)
+    assert isinstance(group, FileGroup)
+    assert group.id == "f56f1e80-31f8-426e-9213-690861252070~4"
+
+
+@pytest.mark.vcr
 def test_file_info_has_new_structure(uploadcare):
     """
     Test new structure of response since API v0.7


### PR DESCRIPTION
## Description

Related issue: #258 

`File.convert` and `File.convert_document` can take an additional parameter called `save_in_group`.

`File.get_converted_document_group` method has been added to get that group that was created upon conversion.


## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
