### PR TITLE
 AWS Rekognition Moderation and bugfixes for addons

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.8](https://github.com/uploadcare/pyuploadcare/compare/v4.1.7...v4.1.8) - soon
+## [4.2.0](https://github.com/uploadcare/pyuploadcare/compare/v4.1.3...v4.2.0) - unreleased
 
 ### Added
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,19 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.8](https://github.com/uploadcare/pyuploadcare/compare/v4.1.7...v4.1.8) - soon
+
+### Added
+
+- For `AddonsAPI` / `AddonLabels`:
+  - Added support for [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
+
+### Fixed
+
+- For `AddonsAPI` / `AddonExecutionParams`:
+  - Fixed the issue where calling `execute` and `status` with `AddonLabels`'s attributes (such as `AddonLabels.REMOVE_BG`) for `addon_name` would result in a _404 Not Found_ error.
+  - Fixed `ValidationError` when constructing `AddonClamAVExecutionParams` or `AddonRemoveBGExecutionParams` with omitted optional parameters.
+
 ## [4.1.3](https://github.com/uploadcare/pyuploadcare/compare/v4.1.2...v4.1.3) - 2023-10-05
 
 ### Added

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -216,18 +216,23 @@ To execute addon call an API `execute` method with the file and parameters::
     target_file = uploadcare.file("59fccca5-3af7-462f-905b-ed7de83b9762")
     # params - from previous step
     remove_bg_result = uploadcare.addons_api.execute(
-        target_file,
+        target_file.uuid,
         AddonLabels.REMOVE_BG,
         remove_bg_params,
     )
 
     aws_recognition_result = uploadcare.addons_api.execute(
-        target_file,
+        target_file.uuid,
         AddonLabels.AWS_LABEL_RECOGNITION,
     )
 
+    aws_moderation_result = uploadcare.addons_api.execute(
+        target_file.uuid,
+        AddonLabels.AWS_MODERATION_LABELS,
+    )
+
     clamav_result = uploadcare.addons_api.execute(
-        target_file,
+        target_file.uuid,
         AddonLabels.CLAM_AV,
         clamav_params,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyuploadcare"
-version = "4.1.3"
+version = "4.2.0"
 description = "Python library for Uploadcare.com"
 authors = ["Uploadcare Inc <hello@uploadcare.com>"]
 readme = "README.md"

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-__version__ = "4.1.2"
+__version__ = "4.2.0"
 
 from pyuploadcare.resources.file import File  # noqa: F401
 from pyuploadcare.resources.file_group import FileGroup  # noqa: F401

--- a/pyuploadcare/api/addon_entities.py
+++ b/pyuploadcare/api/addon_entities.py
@@ -9,6 +9,7 @@ from pyuploadcare.api.entities import Entity
 
 class AddonLabels(str, Enum):
     AWS_LABEL_RECOGNITION = "aws_rekognition_detect_labels"
+    AWS_MODERATION_LABELS = "aws_rekognition_detect_moderation_labels"
     CLAM_AV = "uc_clamav_virus_scan"
     REMOVE_BG = "remove_bg"
 
@@ -38,11 +39,11 @@ class AddonClamAVExecutionRequestData(AddonExecutionGeneralRequestData):
 
 
 class AddonRemoveBGExecutionParams(AddonExecutionParams):
-    crop: bool = Field(
-        False, description="Whether to crop off all empty regions"
+    crop: Optional[bool] = Field(
+        None, description="Whether to crop off all empty regions"
     )
-    crop_margin: str = Field(
-        "0",
+    crop_margin: Optional[str] = Field(
+        None,
         description="Adds a margin around the cropped subject, e.g 30px or 30%",
     )
     scale: Optional[str] = Field(
@@ -50,10 +51,10 @@ class AddonRemoveBGExecutionParams(AddonExecutionParams):
         description="Scales the subject relative to the total image size, e.g 80%",
     )
     add_shadow: Optional[bool] = Field(
-        False, description="Whether to add an artificial shadow to the result"
+        None, description="Whether to add an artificial shadow to the result"
     )
     type_level: Optional[str] = Field(
-        "none",
+        None,
         description="""Enum: "none" "1" "2" "latest"
     "none" = No classification (foreground_type won't bet set in the application data)
     "1" = Use coarse classification classes: [person, product, animal, car, other]
@@ -63,15 +64,16 @@ class AddonRemoveBGExecutionParams(AddonExecutionParams):
     """,
     )
     type: Optional[str] = Field(
-        description="""Foreground type. Enum: "auto" "person" "product" "car"""
+        None,
+        description="""Foreground type. Enum: "auto" "person" "product" "car""",
     )
     semitransparency: Optional[bool] = Field(
-        True,
+        None,
         description="Whether to have semi-transparent regions in the result",
     )
-    channels: Optional[str] = Field("rgba", description="Enum: 'rgba' 'alpha'")
+    channels: Optional[str] = Field(None, description="Enum: 'rgba' 'alpha'")
     roi: Optional[str] = Field(
-        ...,
+        None,
         description="""
         Region of interest:
             Only contents of this rectangular region can be detected as foreground.
@@ -83,7 +85,7 @@ class AddonRemoveBGExecutionParams(AddonExecutionParams):
         """,
     )
     position: Optional[str] = Field(
-        ...,
+        None,
         description="""
         Positions the subject within the image canvas.
         Can be

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -510,8 +510,11 @@ class AddonsAPI(API):
         file_uuid: Union[UUID, str],
         params: Optional[AddonExecutionParams] = None,
     ) -> dict:
+        cleaned_params = {}
+        if params:
+            cleaned_params = params.dict(exclude_unset=True, exclude_none=True)
         execution_request_data = self.request_type.parse_obj(
-            dict(target=str(file_uuid), params=params)
+            dict(target=str(file_uuid), params=cleaned_params)
         )
         return execution_request_data.dict(
             exclude_unset=True, exclude_none=True
@@ -520,9 +523,11 @@ class AddonsAPI(API):
     def execute(
         self,
         file_uuid: Union[UUID, str],
-        addon_name: AddonLabels,
+        addon_name: Union[AddonLabels, str],
         params: Optional[AddonExecutionParams] = None,
     ) -> responses.AddonExecuteResponse:
+        if isinstance(addon_name, AddonLabels):
+            addon_name = addon_name.value
         suffix = f"{addon_name}/execute"
         url = self._build_url(suffix=suffix)
         response_class = self._get_response_class("execute")
@@ -532,8 +537,10 @@ class AddonsAPI(API):
         return cast(responses.AddonExecuteResponse, response)
 
     def status(
-        self, request_id: Union[UUID, str], addon_name: AddonLabels
+        self, request_id: Union[UUID, str], addon_name: Union[AddonLabels, str]
     ) -> responses.AddonResponse:
+        if isinstance(addon_name, AddonLabels):
+            addon_name = addon_name.value
         suffix = f"{addon_name}/execute/status"
         query = dict(request_id=str(request_id))
         url = self._build_url(suffix=suffix, query_parameters=query)

--- a/tests/functional/api/cassettes/test_aws_rekognition_detect_labels_execute.yaml
+++ b/tests/functional/api/cassettes/test_aws_rekognition_detect_labels_execute.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: '{"target": "485f5c0e-3567-46b1-a5c9-96a8ffc45713"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '50'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_labels/execute/
+  response:
+    content: '{"request_id": "6e8424be-749a-4eee-bc1e-05393a7b6938"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 17:03:43 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 6e8424be-749a-4eee-bc1e-05393a7b6938
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_aws_rekognition_detect_labels_status.yaml
+++ b/tests/functional/api/cassettes/test_aws_rekognition_detect_labels_status.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_labels/execute/status/?request_id=6e8424be-749a-4eee-bc1e-05393a7b6938
+  response:
+    content: '{"status": "done"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 17:05:14 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 568d9e58-c2a6-4a87-a589-6e62c93fb3d8
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_aws_rekognition_detect_moderation_labels_execute.yaml
+++ b/tests/functional/api/cassettes/test_aws_rekognition_detect_moderation_labels_execute.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: '{"target": "485f5c0e-3567-46b1-a5c9-96a8ffc45713"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '50'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_moderation_labels/execute/
+  response:
+    content: '{"request_id": "6666a652-a79d-4991-9c4b-3f7705ed7c6c"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 16:40:41 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 6666a652-a79d-4991-9c4b-3f7705ed7c6c
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_aws_rekognition_detect_moderation_labels_status.yaml
+++ b/tests/functional/api/cassettes/test_aws_rekognition_detect_moderation_labels_status.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/addons/aws_rekognition_detect_moderation_labels/execute/status/?request_id=6666a652-a79d-4991-9c4b-3f7705ed7c6c
+  response:
+    content: '{"status": "done"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 16:58:59 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 83aee3a8-cdb3-4684-b364-6278fc8a10b8
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_clam_av_execute.yaml
+++ b/tests/functional/api/cassettes/test_clam_av_execute.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '{"target": "485f5c0e-3567-46b1-a5c9-96a8ffc45713", "params": {"purge_infected":
+      false}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '87'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/addons/uc_clamav_virus_scan/execute/
+  response:
+    content: '{"request_id": "865e5d23-f602-4338-8d3c-fb22f599aa27"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 22:00:36 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 865e5d23-f602-4338-8d3c-fb22f599aa27
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_clam_av_status.yaml
+++ b/tests/functional/api/cassettes/test_clam_av_status.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/addons/uc_clamav_virus_scan/execute/status/?request_id=865e5d23-f602-4338-8d3c-fb22f599aa27
+  response:
+    content: '{"status": "done"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 22:02:44 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 6e403dc5-45f0-4214-b9ff-cfcfd06e825d
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_remove_bg_execute.yaml
+++ b/tests/functional/api/cassettes/test_remove_bg_execute.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '{"target": "485f5c0e-3567-46b1-a5c9-96a8ffc45713", "params": {"crop": true,
+      "add_shadow": true}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '96'
+      content-type:
+      - application/json
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: POST
+    uri: https://api.uploadcare.com/addons/remove_bg/execute/
+  response:
+    content: '{"request_id": "53930d55-8ecb-4b2b-ab9e-3c3b1ffe53cb"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 21:05:49 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 53930d55-8ecb-4b2b-ab9e-3c3b1ffe53cb
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/cassettes/test_remove_bg_status.yaml
+++ b/tests/functional/api/cassettes/test_remove_bg_status.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.1.2/5d5bb5639e3f2df33674 (CPython/3.11.5)
+    method: GET
+    uri: https://api.uploadcare.com/addons/remove_bg/execute/status/?request_id=53930d55-8ecb-4b2b-ab9e-3c3b1ffe53cb
+  response:
+    content: '{"status": "done", "result": {"file_id": "d2a90661-a813-452d-9a38-a3cb7b168548"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Nov 2023 21:07:34 GMT
+      Server:
+      - nginx
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 5264a94b-072f-4877-92c5-8823f8dc2d9e
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/api/test_addons.py
+++ b/tests/functional/api/test_addons.py
@@ -2,6 +2,11 @@ from uuid import uuid4
 
 import pytest
 
+from pyuploadcare.api.addon_entities import (
+    AddonClamAVExecutionParams,
+    AddonLabels,
+    AddonRemoveBGExecutionParams,
+)
 from pyuploadcare.api.api import AddonsAPI
 
 
@@ -13,7 +18,94 @@ def addons_api(uploadcare) -> AddonsAPI:
 def test_request_payload(addons_api):
     file_uuid = uuid4()
 
-    request_data = addons_api._get_request_data(str(file_uuid), None)
+    params = AddonRemoveBGExecutionParams(
+        crop=True,  # should be present
+        scale=None,  # should be left out
+    )
+
+    request_data = addons_api._get_request_data(str(file_uuid), params)
     assert request_data == {
         "target": str(file_uuid),
+        "params": {
+            "crop": True,
+        },
     }
+
+
+@pytest.mark.vcr
+def test_aws_rekognition_detect_labels_execute(uploadcare):
+    result = uploadcare.addons_api.execute(
+        "485f5c0e-3567-46b1-a5c9-96a8ffc45713",
+        AddonLabels.AWS_LABEL_RECOGNITION,
+    )
+    assert str(result.request_id) == "6e8424be-749a-4eee-bc1e-05393a7b6938"
+
+
+@pytest.mark.vcr
+def test_aws_rekognition_detect_labels_status(uploadcare):
+    result = uploadcare.addons_api.status(
+        "6e8424be-749a-4eee-bc1e-05393a7b6938",
+        AddonLabels.AWS_LABEL_RECOGNITION,
+    )
+    assert result.status
+
+
+@pytest.mark.vcr
+def test_aws_rekognition_detect_moderation_labels_execute(uploadcare):
+    assert (
+        AddonLabels.AWS_MODERATION_LABELS.value
+        == "aws_rekognition_detect_moderation_labels"
+    )
+    result = uploadcare.addons_api.execute(
+        "485f5c0e-3567-46b1-a5c9-96a8ffc45713",
+        "aws_rekognition_detect_moderation_labels",  # String values should work here too
+    )
+    assert str(result.request_id) == "6666a652-a79d-4991-9c4b-3f7705ed7c6c"
+
+
+@pytest.mark.vcr
+def test_aws_rekognition_detect_moderation_labels_status(uploadcare):
+    result = uploadcare.addons_api.status(
+        "6666a652-a79d-4991-9c4b-3f7705ed7c6c",
+        "aws_rekognition_detect_moderation_labels",  # String values should work here too
+    )
+    assert result.status
+
+
+@pytest.mark.vcr
+def test_clam_av_execute(uploadcare):
+    params = AddonClamAVExecutionParams(purge_infected=False)
+    result = uploadcare.addons_api.execute(
+        "485f5c0e-3567-46b1-a5c9-96a8ffc45713", AddonLabels.CLAM_AV, params
+    )
+    assert str(result.request_id) == "865e5d23-f602-4338-8d3c-fb22f599aa27"
+
+
+@pytest.mark.vcr
+def test_clam_av_status(uploadcare):
+    result = uploadcare.addons_api.status(
+        "865e5d23-f602-4338-8d3c-fb22f599aa27",
+        AddonLabels.CLAM_AV,
+    )
+    assert result.status
+
+
+@pytest.mark.vcr
+def test_remove_bg_execute(uploadcare):
+    params = AddonRemoveBGExecutionParams(
+        crop=True,
+        add_shadow=True,
+    )
+    result = uploadcare.addons_api.execute(
+        "485f5c0e-3567-46b1-a5c9-96a8ffc45713", AddonLabels.REMOVE_BG, params
+    )
+    assert str(result.request_id) == "53930d55-8ecb-4b2b-ab9e-3c3b1ffe53cb"
+
+
+@pytest.mark.vcr
+def test_remove_bg_status(uploadcare):
+    result = uploadcare.addons_api.status(
+        "53930d55-8ecb-4b2b-ab9e-3c3b1ffe53cb",
+        AddonLabels.REMOVE_BG,
+    )
+    assert result.status


### PR DESCRIPTION
## Description

Related issue: #260 

### Added

- For `AddonsAPI` / `AddonLabels`:
  - Added support for [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).

### Fixed

- For `AddonsAPI` / `AddonExecutionParams`:
  - Fixed the issue where calling `execute` and `status` with `AddonLabels`'s attributes (such as `AddonLabels.REMOVE_BG`) for `addon_name` would result in a _404 Not Found_ error.
  - Fixed `ValidationError` when constructing `AddonClamAVExecutionParams` or `AddonRemoveBGExecutionParams` with omitted optional parameters.

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
- [ ] Update [pyuploadcare-example](https://github.com/uploadcare/pyuploadcare-example)
