### PR TITLE
Add deprecation warnings for GroupsAPI.storage and FileGroup.datetime_stored

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,7 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - For `AddonsAPI` / `AddonLabels`:
   - Added support for [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
 
-### Changed
+### Deprecated
 
 - For `FileGroup`:
   - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,12 +10,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-
 - For `Uploadcare`:
   - Added type for parameter `event` of `create_webhook` and `update_webhook` methods.
 
 - For `AddonsAPI` / `AddonLabels`:
   - Added support for [Unsafe content detection](https://uploadcare.com/docs/unsafe-content/) addon (`AddonLabels.AWS_MODERATION_LABELS`).
+
+### Changed
+
+- For `FileGroup`:
+  - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API.
+
+- For `GroupsAPI`:
+  - Added a deprecation warning when calling `store` method, as it has been deprecated in the REST API.
 
 ### Fixed
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -52,10 +52,12 @@ There are no breaking changes in this release.
 ### Deprecated
 
 - For `FileGroup`:
-  - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API.
+  - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API. This field does not exist in REST API v0.7.x.
 
 - For `GroupsAPI`:
-  - Added a deprecation warning when calling `store` method, as it has been deprecated in the REST API.
+  - Added a deprecation warning when calling `store` method, as it has been deprecated in the REST API. This API endpoint does not exist in REST API v0.7.x.
+
+- `AkamaiSecureUrlBuilder` has been renamed to `AkamaiSecureUrlBuilderWithAclToken`. It is still available under the old name and works as before, but it will issue a deprecation warning when used.
 
 ### Fixed
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.3](https://github.com/uploadcare/pyuploadcare/compare/v4.2.2...v4.2.3) - unreleased
+
+### Deprecated
+
+- For `FileGroup`:
+  - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API. This field does not exist in REST API v0.7.x.
+
+- For `GroupsAPI`:
+  - Added a deprecation warning when calling `store` method, as it has been deprecated in the REST API. This API endpoint does not exist in REST API v0.7.x.
+
 ## [4.2.2](https://github.com/uploadcare/pyuploadcare/compare/v4.2.1...v4.2.2) - 2023-11-20
 
 ### Added
@@ -60,16 +70,6 @@ There are no breaking changes in this release.
 - Introduced `AkamaiSecureUrlBuilderWithUrlToken` class.
 
 ### Changed
-
-- `AkamaiSecureUrlBuilder` has been renamed to `AkamaiSecureUrlBuilderWithAclToken`. It is still available under the old name and works as before, but it will issue a deprecation warning when used.
-
-### Deprecated
-
-- For `FileGroup`:
-  - Added a deprecation warning when accessing `datetime_stored` property, as it has been deprecated in the REST API. This field does not exist in REST API v0.7.x.
-
-- For `GroupsAPI`:
-  - Added a deprecation warning when calling `store` method, as it has been deprecated in the REST API. This API endpoint does not exist in REST API v0.7.x.
 
 - `AkamaiSecureUrlBuilder` has been renamed to `AkamaiSecureUrlBuilderWithAclToken`. It is still available under the old name and works as before, but it will issue a deprecation warning when used.
 

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+import warnings
 from json import JSONDecodeError
 from time import time
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
@@ -122,6 +123,11 @@ class GroupsAPI(API, ListCountMixin, RetrieveMixin, DeleteMixin):
     }
 
     def store(self, file_uuid: Union[UUID, str]) -> Dict[str, Any]:
+        warnings.warn(
+            "/groups/:uuid/storage/ REST API endpoint is deprecated: "
+            "https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Changelog",
+            DeprecationWarning,
+        )
         url = self._build_url(file_uuid, suffix="storage")
         return self._client.put(url).json()
 

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -124,7 +124,7 @@ class GroupsAPI(API, ListCountMixin, RetrieveMixin, DeleteMixin):
 
     def store(self, file_uuid: Union[UUID, str]) -> Dict[str, Any]:
         warnings.warn(
-            "/groups/:uuid/storage/ REST API endpoint is deprecated: "
+            "/groups/:uuid/storage/ endpoint has been removed from REST API v0.7"
             "https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/Changelog",
             DeprecationWarning,
         )

--- a/pyuploadcare/resources/file_group.py
+++ b/pyuploadcare/resources/file_group.py
@@ -154,7 +154,7 @@ class FileGroup(Iterable):
     def datetime_stored(self):
         """Returns file group's store aware *datetime* in UTC format."""
         warnings.warn(
-            "datetime_stored field is deprecated in the REST API.",
+            "datetime_stored has been removed from REST API v0.7",
             DeprecationWarning,
         )
         datetime_ = self.info.get("datetime_stored")

--- a/pyuploadcare/resources/file_group.py
+++ b/pyuploadcare/resources/file_group.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional
 
@@ -152,6 +153,10 @@ class FileGroup(Iterable):
     @property
     def datetime_stored(self):
         """Returns file group's store aware *datetime* in UTC format."""
+        warnings.warn(
+            "datetime_stored field is deprecated in the REST API.",
+            DeprecationWarning,
+        )
         datetime_ = self.info.get("datetime_stored")
         if isinstance(datetime_, str):
             return dateutil.parser.parse(datetime_)


### PR DESCRIPTION
## Description

Related issue: #261 

Added just a couple `DeprecationWarning`s

## Checklist

- [ ] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
