### PR TITLE
fix AttributeError: 'dict' object has no attribute 'dict' in AddonsAPI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1](https://github.com/uploadcare/pyuploadcare/compare/v4.2.0...v4.2.1) - 2023-11-17
+
+### Fixed
+
+- For `AddonsAPI`:
+  - In version 4.2.0, passing a Python dictionary as `params` to the `execute` method would cause an `AttributeError`. Now, you can use either an `AddonExecutionParams` instance or a `dict`.
+
 ## [4.2.0](https://github.com/uploadcare/pyuploadcare/compare/v4.1.3...v4.2.0) - 2023-11-16
 
 Summary of this update:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyuploadcare"
-version = "4.2.0"
+version = "4.2.1"
 description = "Python library for Uploadcare.com"
 authors = ["Uploadcare Inc <hello@uploadcare.com>"]
 readme = "README.md"

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 from pyuploadcare.resources.file import File  # noqa: F401
 from pyuploadcare.resources.file_group import FileGroup  # noqa: F401

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -522,11 +522,16 @@ class AddonsAPI(API):
     def _get_request_data(
         self,
         file_uuid: Union[UUID, str],
-        params: Optional[AddonExecutionParams] = None,
+        params: Optional[Union[AddonExecutionParams, dict]] = None,
     ) -> dict:
         cleaned_params = {}
         if params:
-            cleaned_params = params.dict(exclude_unset=True, exclude_none=True)
+            if isinstance(params, AddonExecutionParams):
+                cleaned_params = params.dict(
+                    exclude_unset=True, exclude_none=True
+                )
+            else:
+                cleaned_params = params
         execution_request_data = self.request_type.parse_obj(
             dict(target=str(file_uuid), params=cleaned_params)
         )
@@ -538,7 +543,7 @@ class AddonsAPI(API):
         self,
         file_uuid: Union[UUID, str],
         addon_name: Union[AddonLabels, str],
-        params: Optional[AddonExecutionParams] = None,
+        params: Optional[Union[AddonExecutionParams, dict]] = None,
     ) -> responses.AddonExecuteResponse:
         if isinstance(addon_name, AddonLabels):
             addon_name = addon_name.value


### PR DESCRIPTION
## Description

Before version 4.2.0, parameters for `AddonsAPI.execute` could be passed as a simple dictionary:

```python
remove_bg_result = uploadcare.addons_api.execute(
    target_file.uuid,
    {
        "crop": True,
        "crop_margin": "20px",
        "scale": "15%",
    },
    remove_bg_params,
)
```

Although this method is not officially documented (the recommended approach is to use`AddonRemoveBGExecutionParams` / `AddonClamAVExecutionParams`), some people might use it. 

Notably, it is the way [pyuploadcare-example](https://github.com/uploadcare/pyuploadcare-example) works. With `pyuploadcare==4.2.0` it raises an `AttributeError`.

<details><summary>Details</summary>
<pre>
Request Method: POST
Request URL: http://127.0.0.1:8000/addons/remove_bg/execute/

Traceback (most recent call last):
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/django/views/generic/edit.py", line 142, in post
    return self.form_valid(form)
  File "/Users/evgkirov/Documents/Projects/pyuploadcare-example/app/uploadcare/views/addons.py", line 64, in form_valid
    response = uploadcare.addons_api.execute(target_uuid, self.addon_name, params=params)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/pyuploadcare/api/api.py", line 548, in execute
    request_payload = self._get_request_data(file_uuid, params)
  File "/Users/evgkirov/Library/Caches/pypoetry/virtualenvs/pyuploadcare-example-LVXcg9rd-py3.11/lib/python3.11/site-packages/pyuploadcare/api/api.py", line 529, in _get_request_data
    cleaned_params = params.dict(exclude_unset=True, exclude_none=True)

Exception Type: AttributeError at /addons/remove_bg/execute/
Exception Value: 'dict' object has no attribute 'dict'
</pre>
</details> 

This PR enhances flexibility and acknowledges existing informal usage patterns.



## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))

