### PR TITLE
#260 added File.info["appdata"]["aws_rekognition_detect_moderation_labels"]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.2](https://github.com/uploadcare/pyuploadcare/compare/v4.2.1...v4.2.2) - 2023-11-20
+
+### Added
+
+- For `File`:
+  - AWS Rekognition Moderation results are now accessible via `File.info["appdata"]["aws_rekognition_detect_moderation_labels"]`.
+
 ## [4.2.1](https://github.com/uploadcare/pyuploadcare/compare/v4.2.0...v4.2.1) - 2023-11-17
 
 ### Fixed

--- a/docs/core_api.rst
+++ b/docs/core_api.rst
@@ -251,6 +251,9 @@ To check status of performed task use `status` method::
 
 If addon execution produces new data for file (like an AWS recognition does), this data will be placed at `appdata` complex attribute of `File.info` (see `addons documentation`_)
 
+    file.update_info(include_appdata=True)
+    print(file.info["appdata"]["aws_rekognition_detect_labels"])
+
 
 File metadata
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyuploadcare"
-version = "4.2.1"
+version = "4.2.2"
 description = "Python library for Uploadcare.com"
 authors = ["Uploadcare Inc <hello@uploadcare.com>"]
 readme = "README.md"

--- a/pyuploadcare/__init__.py
+++ b/pyuploadcare/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 from pyuploadcare.resources.file import File  # noqa: F401
 from pyuploadcare.resources.file_group import FileGroup  # noqa: F401

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -146,6 +146,23 @@ class AWSRecognitionDetectLabelsApplicationData(ApplicationDataBase):
     data: AWSRecognitionDetectLabelsDetails
 
 
+class AWSRecognitionModerationLabel(Entity):
+    confidence: Decimal = Field(alias="Confidence")
+    name: str = Field(alias="Name")
+    parent_name: str = Field(alias="ParentName")
+
+
+class AWSRecognitionDetectModerationLabelsDetails(ApllicationDataDetails):
+    label_model_version: Optional[str] = Field(alias="ModerationModelVersion")
+    labels: List[AWSRecognitionModerationLabel] = Field(
+        alias="ModerationLabels", default_factory=list
+    )
+
+
+class AWSRecognitionDetectModerationLabelsApplicationData(ApplicationDataBase):
+    data: AWSRecognitionDetectModerationLabelsDetails
+
+
 class RemoveBackgroundDetails(ApllicationDataDetails):
     foreground_type: Optional[str]
 
@@ -166,6 +183,9 @@ class UCClamAVApplicationData(ApplicationDataBase):
 class ApplicationDataSet(Entity):
     aws_rekognition_detect_labels: Optional[
         AWSRecognitionDetectLabelsApplicationData
+    ]
+    aws_rekognition_detect_moderation_labels: Optional[
+        AWSRecognitionDetectModerationLabelsApplicationData
     ]
     remove_bg: Optional[RemoveBackgroundApplicationData]
     uc_clamav_virus_scan: Optional[UCClamAVApplicationData]

--- a/tests/functional/resources/cassettes/test_retrieve_fileinfo_with_appdata.yaml
+++ b/tests/functional/resources/cassettes/test_retrieve_fileinfo_with_appdata.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.uploadcare.com
+      user-agent:
+      - PyUploadcare/4.2.1/5d5bb5639e3f2df33674 (CPython/3.11.6)
+    method: GET
+    uri: https://api.uploadcare.com/files/04bd49fa-466d-49e7-afd7-bac108055371/?include=appdata
+  response:
+    content: '{"datetime_removed":null,"datetime_stored":"2023-11-16T22:43:33.133404Z","datetime_uploaded":"2023-11-16T22:43:32.941596Z","is_image":true,"is_ready":true,"mime_type":"image/jpeg","original_file_url":"https://ucarecdn.com/04bd49fa-466d-49e7-afd7-bac108055371/IMG_8919.jpeg","original_filename":"IMG_8919.jpeg","size":2738012,"url":"https://api.uploadcare.com/files/04bd49fa-466d-49e7-afd7-bac108055371/","uuid":"04bd49fa-466d-49e7-afd7-bac108055371","variations":null,"content_info":{"mime":{"mime":"image/jpeg","type":"image","subtype":"jpeg"},"image":{"dpi":[72,72],"width":3011,"format":"JPEG","height":4516,"sequence":false,"color_mode":"RGB","orientation":1,"geo_location":null,"datetime_original":"2023-03-10T16:23:15"}},"metadata":{},"appdata":{"uc_clamav_virus_scan":{"data":{"infected":false},"datetime_created":"2023-11-16T22:43:33.240822Z","datetime_updated":"2023-11-16T22:43:33.240840Z","version":"1.0.1"},"aws_rekognition_detect_labels":{"data":{"Labels":[{"Name":"Accessories","Parents":[],"Instances":[],"Confidence":99.99989318847656},{"Name":"Strap","Parents":[{"Name":"Accessories"}],"Instances":[],"Confidence":99.99989318847656},{"Name":"Path","Parents":[],"Instances":[],"Confidence":99.9789810180664},{"Name":"Road","Parents":[],"Instances":[],"Confidence":99.6391830444336},{"Name":"Street","Parents":[{"Name":"City"},{"Name":"Road"},{"Name":"Urban"}],"Instances":[],"Confidence":98.96985626220703},{"Name":"Dog","Parents":[{"Name":"Animal"},{"Name":"Canine"},{"Name":"Mammal"},{"Name":"Pet"}],"Instances":[{"Confidence":96.09213256835938,"BoundingBox":{"Top":0.22825734317302704,"Left":0.21121233701705933,"Width":0.6009787321090698,"Height":0.5943910479545593}}],"Confidence":97.46222686767578},{"Name":"Husky","Parents":[{"Name":"Animal"},{"Name":"Canine"},{"Name":"Dog"},{"Name":"Mammal"},{"Name":"Pet"}],"Instances":[],"Confidence":97.46222686767578},{"Name":"Leash","Parents":[],"Instances":[],"Confidence":95.12698364257812},{"Name":"Tarmac","Parents":[{"Name":"Road"}],"Instances":[],"Confidence":94.74235534667969},{"Name":"Sidewalk","Parents":[{"Name":"Path"}],"Instances":[],"Confidence":91.32418823242188}],"LabelModelVersion":"3.0"},"datetime_created":"2023-11-16T22:43:34.151968Z","datetime_updated":"2023-11-16T22:43:34.151992Z","version":"2016-06-27"},"aws_rekognition_detect_moderation_labels":{"data":{"ModerationLabels":[{ "Confidence": 93.41645812988281, "Name": "Weapons", "ParentName": "Violence" }],"ModerationModelVersion":"6.1"},"datetime_created":"2023-11-16T22:55:25.482969Z","datetime_updated":"2023-11-16T23:54:56.243287Z","version":"2016-06-27"}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2521'
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Date:
+      - Sun, 19 Nov 2023 17:53:38 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      X-Uploadcare-Request-Id:
+      - 1a75e573-84e7-4ec4-a681-c1844265f906
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -362,6 +362,35 @@ def test_list_files(uploadcare):
 def test_retrieve_fileinfo_with_metadata(uploadcare):
     file_ = uploadcare.file("a55d6b25-d03c-4038-9838-6e06bb7df598")
     assert isinstance(file_, File)
+    assert file_.info
 
     metadata_dict = file_.info["metadata"]
     assert len(metadata_dict) == 2
+
+
+@pytest.mark.vcr
+def test_retrieve_fileinfo_with_appdata(uploadcare):
+    file_ = uploadcare.file("04bd49fa-466d-49e7-afd7-bac108055371")
+    assert isinstance(file_, File)
+    file_.update_info(include_appdata=True)
+    assert file_.info
+    appdata = file_.info["appdata"]
+
+    assert "aws_rekognition_detect_labels" in appdata
+    labels_data = appdata["aws_rekognition_detect_labels"]
+    labels_details = labels_data["data"]
+    assert labels_details["label_model_version"]
+    assert len(labels_details["labels"]) == 10
+    label = labels_details["labels"][0]
+    assert label["confidence"]
+    assert label["name"] == "Accessories"
+
+    assert "aws_rekognition_detect_moderation_labels" in appdata
+    moderation_data = appdata["aws_rekognition_detect_moderation_labels"]
+    moderation_details = moderation_data["data"]
+    assert moderation_details["label_model_version"]
+    assert len(moderation_details["labels"]) == 1
+    moderation_label = moderation_details["labels"][0]
+    assert moderation_label["confidence"]
+    assert moderation_label["name"] == "Weapons"
+    assert moderation_label["parent_name"] == "Violence"


### PR DESCRIPTION
## Description

In `File.info["appdata"]`, AWS Rekognition Moderation results was missing. This pull request fixes that.

Related issue #260.

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
