### PR TITLE
Update Black to v24.3.0 & fix warnings in the pipelines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 max-line-length = 100
 max-complexity = 5
 exclude = .venv,venv,**/migrations/*,snapshots
+extend-ignore = E203,E701
 per-file-ignores =
     tests/**: S101
     **/tests/**: S101

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Install Poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -46,9 +46,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -79,9 +79,9 @@ jobs:
             django-version: "3.2"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
@@ -120,9 +120,9 @@ jobs:
             django-version: "4.2"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
@@ -151,9 +151,9 @@ jobs:
         django-version: ["5.0"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
@@ -180,9 +180,9 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - For `ImageTransformation`:
   - The `overlay()` and `overlay_self()` methods now treat `overlay_width` and `overlay_height` parameters as optional.
   - Unified `gif2video()`, `gif2video_format()`, and `gif2video_quality()` methods into a single `gif2video()` method. The `format` and `quality` parameters can now be accepted directly in the `gif2video()` method.
+- [Black](https://black.readthedocs.io/) dev dependency has been updated to 24.3.0.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 79
-target-version = ['py39']
+target-version = ['py38']
 exclude = '''
 (
   \.eggs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ django = ["Django"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4"
-black = "^23.12.0"
+black = "^24.3.0"
 isort = "^5.13.2"
 flake8 = "^6.1.0"
 mypy = "^1.7.1"

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -517,9 +517,9 @@ class MetadataAPI(API):
 
 class AddonsAPI(API):
     resource_type = "addons"
-    request_type: Type[
+    request_type: Type[AddonExecutionGeneralRequestData] = (
         AddonExecutionGeneralRequestData
-    ] = AddonExecutionGeneralRequestData
+    )
     response_classes = {
         "execute": responses.AddonExecuteResponse,
         "status": responses.AddonResponse,

--- a/pyuploadcare/api/auth.py
+++ b/pyuploadcare/api/auth.py
@@ -7,8 +7,7 @@ from httpx import Auth, Request, Response
 from httpx._utils import to_bytes, to_str
 
 
-class AuthBase(Auth):
-    ...
+class AuthBase(Auth): ...
 
 
 class UploadcareSimpleAuth(AuthBase):
@@ -28,9 +27,9 @@ class UploadcareSimpleAuth(AuthBase):
         if "Content-Type" not in request.headers:
             request.headers["Content-Type"] = "application/json"
 
-        request.headers[
-            "Accept"
-        ] = f"application/vnd.uploadcare-v{self.api_version}+json"
+        request.headers["Accept"] = (
+            f"application/vnd.uploadcare-v{self.api_version}+json"
+        )
         request.headers["Authorization"] = self._build_auth_header(
             request, self.public_key, self.secret_key
         )
@@ -56,9 +55,9 @@ class UploadcareAuth(UploadcareSimpleAuth):
         if "Content-Type" not in request.headers:
             request.headers["Content-Type"] = "application/json"
 
-        request.headers[
-            "Accept"
-        ] = f"application/vnd.uploadcare-v{self.api_version}+json"
+        request.headers["Accept"] = (
+            f"application/vnd.uploadcare-v{self.api_version}+json"
+        )
         request.headers["Authorization"] = self._build_auth_header(
             request, self.public_key, self.secret_key, formated_date_time
         )

--- a/pyuploadcare/api/base.py
+++ b/pyuploadcare/api/base.py
@@ -118,8 +118,7 @@ class APIProtocol(Protocol):
         self,
         raw_resource: Dict[str, Any],
         response_class: Type[ResponseOrEntity],
-    ) -> ResponseOrEntity:
-        ...
+    ) -> ResponseOrEntity: ...
 
     def _build_url(
         self,
@@ -127,40 +126,33 @@ class APIProtocol(Protocol):
         base: Optional[str] = None,
         suffix: Optional[str] = None,
         query_parameters: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        ...
+    ) -> str: ...
 
     def _get_response_class(
         self, action: str
-    ) -> Union[Type[Response], Type[Entity]]:
-        ...
+    ) -> Union[Type[Response], Type[Entity]]: ...
 
-    def _post(self, data: Optional[Dict] = None) -> Dict[str, Any]:
-        ...
+    def _post(self, data: Optional[Dict] = None) -> Dict[str, Any]: ...
 
     def _get(
         self,
         resource_uuid: Optional[Union[UUID, str, UUIDEntity]] = None,
         **query_parameters,
-    ) -> Dict[str, Any]:
-        ...
+    ) -> Dict[str, Any]: ...
 
     def _put(
         self,
         resource_uuid: Optional[Union[UUID, str, UUIDEntity]] = None,
         data: Optional[Dict] = None,
-    ) -> Dict[str, Any]:
-        ...
+    ) -> Dict[str, Any]: ...
 
     def _delete(
         self, resource_uuid: Optional[Union[UUID, str, UUIDEntity]] = None
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def _delete_with_response(
         self, resource_uuid: Optional[Union[UUID, str, UUIDEntity]] = None
-    ) -> Dict[str, Any]:
-        ...
+    ) -> Dict[str, Any]: ...
 
 
 class RetrieveMixin(APIProtocol):

--- a/pyuploadcare/api/entities.py
+++ b/pyuploadcare/api/entities.py
@@ -10,8 +10,7 @@ from typing_extensions import Annotated, Literal, NamedTuple
 from .metadata import META_KEY_MAX_LEN, META_KEY_PATTERN, META_VALUE_MAX_LEN
 
 
-class Entity(BaseModel):
-    ...
+class Entity(BaseModel): ...
 
 
 class IDEntity(Entity):

--- a/pyuploadcare/api/responses.py
+++ b/pyuploadcare/api/responses.py
@@ -14,8 +14,7 @@ from pyuploadcare.api.entities import (
 )
 
 
-class Response(BaseModel):
-    ...
+class Response(BaseModel): ...
 
 
 class EntityListResponse(Response):

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -123,10 +123,9 @@ def test_file_upload_by_url_callback(vcr, uploadcare):
 
 @pytest.mark.vcr
 def test_file_upload_multiple(small_file, small_file2, uploadcare):
-    with (
-        open(small_file.name, mode="rb") as file1,
-        open(small_file2.name, mode="rb") as file2,
-    ):
+    with open(small_file.name, mode="rb") as file1, open(
+        small_file2.name, mode="rb"
+    ) as file2:
         files = uploadcare.upload_files([file1, file2])
         created_filenames = [file.filename for file in files]
         assert sorted(created_filenames) == sorted(

--- a/tests/functional/resources/test_resources.py
+++ b/tests/functional/resources/test_resources.py
@@ -123,9 +123,10 @@ def test_file_upload_by_url_callback(vcr, uploadcare):
 
 @pytest.mark.vcr
 def test_file_upload_multiple(small_file, small_file2, uploadcare):
-    with open(small_file.name, mode="rb") as file1, open(
-        small_file2.name, mode="rb"
-    ) as file2:
+    with (
+        open(small_file.name, mode="rb") as file1,
+        open(small_file2.name, mode="rb") as file2,
+    ):
         files = uploadcare.upload_files([file1, file2])
         created_filenames = [file.filename for file in files]
         assert sorted(created_filenames) == sorted(


### PR DESCRIPTION
## Description

`black` before 24.3.0 contains [CVE-2024-21503](https://github.com/uploadcare/pyuploadcare/security/dependabot/3)

Although we're not actually affected by this vulnerability as we don’t run `black` on untrusted code, it's better to have it updated rather than not.

---

GitHub Actions were updated:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.



## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
