### PR TITLE
Chore: update httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ ucare = 'pyuploadcare.ucare_cli.main:main'
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-httpx = "^0.25.1"
+httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.5.2"}
 python-dateutil = "^2.8.2"
 pytz = "^2023.3.post1"


### PR DESCRIPTION
## Description
Update `httpx` to the latest version. This was causing dependency resolution issues in projects that want to use `pyuploadcare` as a dependency.

Example error from poetry:
> ❯ poetry add pyuploadcare
> Using version ^6.0.0 for pyuploadcare
> 
> Updating dependencies
> Resolving dependencies... (0.0s)
> 
> Because no versions of pyuploadcare match >6.0.0,<7.0.0
>  and pyuploadcare (6.0.0) depends on httpx (>=0.25.1,<0.26.0), pyuploadcare (>=6.0.0,<7.0.0) requires httpx (>=0.25.1,<0.26.0).
> So, because your-project depends on both httpx (>=0.28.1,<0.29.0) and pyuploadcare (^6.0.0), version solving failed.
> 

## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
