### PR TITLE
chore: update pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ucare = 'pyuploadcare.ucare_cli.main:main'
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12.9"
+python = ">=3.9,<=3.12.9"
 httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.5.2"}
 python-dateutil = "^2.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ python = "^3.8.1"
 httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.5.2"}
 python-dateutil = "^2.8.2"
-pytz = "^2023.3.post1"
+pytz = "^2025.1"
 typing-extensions = "^4.9.0"
 Django = {version = ">=2.2", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ucare = 'pyuploadcare.ucare_cli.main:main'
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = ">=3.9,<3.12.9"
 httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.5.2"}
 python-dateutil = "^2.8.2"
@@ -51,7 +51,7 @@ coverage = "^7.3.3"
 pytest-cov = "^4.1.0"
 python-coveralls = "^2.9.3"
 types-python-dateutil = "^2.8.19.14"
-types-pytz = "^2023.3.1.1"
+types-pytz = "^2025.1.0.20250204"
 Sphinx = "^7.1.2"
 sphinx-argparse = "^0.4.0"
 types-dataclasses = "^0.6.6"


### PR DESCRIPTION
## Description

Update `pytz` to the latest version. This was causing dependency resolution issues in projects that want to use pyuploadcare as a dependency.

Example error from poetry:

> ❯ poetry lock   
> Resolving dependencies... (2.0s)
> 
> Because no versions of vellum-ai match >0.14.3,<0.14.4 || >0.14.4,<0.14.5 || >0.14.5,<0.14.6 || >0.14.6,<0.14.7 || >0.14.7,<0.14.8 || >0.14.8,<0.14.9 || >0.14.9,<0.14.10 || >0.14.10,<0.14.11 || >0.14.11,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0
>  and vellum-ai (0.14.3) depends on pytz (2022.6), vellum-ai (>=0.14.3,<0.14.4 || >0.14.4,<0.14.5 || >0.14.5,<0.14.6 || >0.14.6,<0.14.7 || >0.14.7,<0.14.8 || >0.14.8,<0.14.9 || >0.14.9,<0.14.10 || >0.14.10,<0.14.11 || >0.14.11,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0) requires pytz (2022.6).
> And because vellum-ai (0.14.4) depends on pytz (2022.6)
>  and vellum-ai (0.14.5) depends on pytz (2022.6), vellum-ai (>=0.14.3,<0.14.6 || >0.14.6,<0.14.7 || >0.14.7,<0.14.8 || >0.14.8,<0.14.9 || >0.14.9,<0.14.10 || >0.14.10,<0.14.11 || >0.14.11,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0) requires pytz (2022.6).
> And because vellum-ai (0.14.6) depends on pytz (2022.6)
>  and vellum-ai (0.14.7) depends on pytz (2022.6), vellum-ai (>=0.14.3,<0.14.8 || >0.14.8,<0.14.9 || >0.14.9,<0.14.10 || >0.14.10,<0.14.11 || >0.14.11,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0) requires pytz (2022.6).
> And because vellum-ai (0.14.8) depends on pytz (2022.6)
>  and vellum-ai (0.14.9) depends on pytz (2022.6), vellum-ai (>=0.14.3,<0.14.10 || >0.14.10,<0.14.11 || >0.14.11,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0) requires pytz (2022.6).
> And because vellum-ai (0.14.10) depends on pytz (2022.6)
>  and vellum-ai (0.14.11) depends on pytz (2022.6), vellum-ai (>=0.14.3,<0.14.12 || >0.14.12,<0.14.13 || >0.14.13,<0.15.0) requires pytz (2022.6).
> And because vellum-ai (0.14.12) depends on pytz (2025.1)
>  and vellum-ai (0.14.13) depends on pytz (2025.1), vellum-ai (>=0.14.3,<0.15.0) requires pytz (2022.6 || 2025.1).
> Because no versions of pyuploadcare match >6.1.0,<7.0.0
>  and pyuploadcare (6.1.0) depends on pytz (>=2023.3.post1,<2024.0), pyuploadcare (>=6.1.0,<7.0.0) requires pytz (>=2023.3.post1,<2024.0).
> Thus, pyuploadcare (>=6.1.0,<7.0.0) is incompatible with vellum-ai (>=0.14.3,<0.15.0).
> So, because docsum-api depends on both vellum-ai (^0.14.3) and pyuploadcare (^6.1.0), version solving failed.

## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
