### PR TITLE
Remove unused dependency 'pytz' from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ python = ">=3.8,<3.15"
 httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.5.2"}
 python-dateutil = "^2.8.2"
-pytz = "^2025.1"
 typing-extensions = "^4.9.0"
 Django = {version = ">=2.2", optional = true}
 


### PR DESCRIPTION
## Description

As part of our ongoing research on Python dependency management, we identified a potential improvement in your project’s approach.

Specifically, the dependency `pytz` is listed in `pyproject.toml`, but doesn’t appear to be used anywhere in the codebase.

Cleaning it up can make your project easier to maintain and a bit safer in the long run.

Hope this is helpful!


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
