### PR TITLE
Use httpx2 on newer pythons

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.9"
+          python-version: "3.13"
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: Install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: Run linters
         run: make lint
 
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,14 +50,62 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: Install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: Test with pytest
+        run: make test-functional
+
+  # Python 3.8 is handled separately: Poetry 2.x (required by the lock file)
+  # needs Python >=3.9, and modern virtualenv can no longer seed pip for 3.8.
+  py38-functional:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.8"
+      - name: Install Poetry and create the 3.8 virtualenv
         run: |
-          make test-functional
+          pipx install poetry==2.4.1
+          poetry config virtualenvs.create false
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
+      - name: Install dependencies
+        run: poetry install --with dev
+      - name: Test with pytest
+        run: make test-functional
+
+  py38-django:
+    needs: py38-functional
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        django-version: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.8"
+      - name: Install Poetry and create the 3.8 virtualenv
+        run: |
+          pipx install poetry==2.4.1
+          poetry config virtualenvs.create false
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
+      - name: Install dependencies
+        run: poetry install --with dev
+      - name: Install specific django version
+        run: poetry run pip install django~=${{ matrix.django-version }}
+      - name: Test with pytest
+        run: make test-django
 
   django-2-and-3:
     needs: functional
@@ -66,7 +114,7 @@ jobs:
       matrix:
         # https://docs.djangoproject.com/en/2.2/faq/install/#what-python-version-can-i-use-with-django
         # https://docs.djangoproject.com/en/3.2/faq/install/#what-python-version-can-i-use-with-django
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9"]
         django-version: ["2.2", "3.0", "3.1", "3.2"]
 
         include:
@@ -80,17 +128,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: install specific django version
-        run: |
-          poetry run pip install django~=${{ matrix.django-version }}
+        run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
-        run: |
-          make test-django
+        run: make test-django
 
   django-4:
     needs: functional
@@ -98,7 +144,7 @@ jobs:
     strategy:
       matrix:
         # https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         django-version: ["4.0", "4.1", "4.2"]
 
         include:
@@ -118,17 +164,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: install specific django version
-        run: |
-          poetry run pip install django~=${{ matrix.django-version }}
+        run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
-        run: |
-          make test-django
+        run: make test-django
 
   django-5:
     needs: functional
@@ -148,17 +192,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: install specific django version
-        run: |
-          poetry run pip install django~=${{ matrix.django-version }}
+        run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
-        run: |
-          make test-django
+        run: make test-django
 
   django-6:
     needs: functional
@@ -175,17 +217,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: install specific django version
-        run: |
-          poetry run pip install django~=${{ matrix.django-version }}
+        run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
-        run: |
-          make test-django
+        run: make test-django
 
   integration:
     needs: functional
@@ -201,14 +241,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pipx install poetry==2.4.1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
       - name: Install dependencies
-        run: |
-          poetry env use python
-          poetry install --with dev
+        run: poetry install --with dev
       - name: Test with pytest
-        run: |
-          make test-integration
+        run: make test-integration
         env:
           UPLOADCARE_PUBLIC_KEY: ${{ secrets.UPLOADCARE_PUBLIC_KEY }}
           UPLOADCARE_SECRET_KEY: ${{ secrets.UPLOADCARE_SECRET_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
       - "feature/**"
       - "version-3.x/**"
 
+env:
+  POETRY_INSTALLER_ONLY_BINARY: ":all:"
+  POETRY_VERSION: "2.4.1"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -28,10 +32,8 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: Install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Run linters
         run: make lint
@@ -54,10 +56,8 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: Install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Test with pytest
         run: make test-functional
@@ -79,15 +79,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry and create the virtualenv
         run: |
-          pipx install poetry==2.4.1
+          pipx install poetry==${{ env.POETRY_VERSION }}
           poetry config virtualenvs.create false
           python -m venv .venv
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: poetry install --with dev
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: Test with pytest
         run: make test-functional
 
@@ -106,15 +104,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry and create the virtualenv
         run: |
-          pipx install poetry==2.4.1
+          pipx install poetry==${{ env.POETRY_VERSION }}
           poetry config virtualenvs.create false
           python -m venv .venv
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: poetry install --with dev
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: Install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
       - name: Test with pytest
@@ -139,11 +135,9 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: install dependencies
         run: poetry install --with dev
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
@@ -177,10 +171,8 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -207,10 +199,8 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -234,10 +224,8 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -260,10 +248,8 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: "2.4.1"
+          version: ${{ env.POETRY_VERSION }}
       - name: Install dependencies
-        env:
-          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Test with pytest
         run: make test-integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: Install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: Run linters
         run: make lint
@@ -53,13 +50,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: Install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: Test with pytest
         run: |
@@ -86,13 +80,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: install specific django version
         run: |
@@ -127,13 +118,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: install specific django version
         run: |
@@ -160,13 +148,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: install specific django version
         run: |
@@ -190,13 +175,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: install specific django version
         run: |
@@ -219,13 +201,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: false
+        run: pipx install poetry==2.4.1
       - name: Install dependencies
         run: |
+          poetry env use python
           poetry install --with dev
       - name: Test with pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: Install dependencies
@@ -54,7 +55,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: 1.4.2
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: Install dependencies
@@ -87,7 +88,7 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: 1.4.2
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: install dependencies
@@ -128,7 +129,7 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: 1.4.2
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: install dependencies
@@ -161,7 +162,7 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
-          version: 1.4.2
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: install dependencies
@@ -191,6 +192,7 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: install dependencies
@@ -219,6 +221,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
+          version: "2.4.1"
           virtualenvs-create: true
           virtualenvs-in-project: false
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: Install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Run linters
         run: make lint
@@ -54,6 +56,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: Install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Test with pytest
         run: make test-functional
@@ -82,6 +86,8 @@ jobs:
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: poetry install --with dev
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: Test with pytest
         run: make test-functional
 
@@ -107,6 +113,8 @@ jobs:
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: poetry install --with dev
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: Install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
       - name: Test with pytest
@@ -134,6 +142,8 @@ jobs:
           version: "2.4.1"
       - name: install dependencies
         run: poetry install --with dev
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
       - name: test with pytest
@@ -169,6 +179,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -197,6 +209,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -222,6 +236,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: install specific django version
         run: poetry run pip install django~=${{ matrix.django-version }}
@@ -246,6 +262,8 @@ jobs:
         with:
           version: "2.4.1"
       - name: Install dependencies
+        env:
+          POETRY_INSTALLER_ONLY_BINARY: ":all:"
         run: poetry install --with dev
       - name: Test with pytest
         run: make test-integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,18 +58,22 @@ jobs:
       - name: Test with pytest
         run: make test-functional
 
-  # Python 3.8 is handled separately: Poetry 2.x (required by the lock file)
-  # needs Python >=3.9, and modern virtualenv can no longer seed pip for 3.8.
-  py38-functional:
+  # Python <3.10 is handled separately: Poetry 2.x (required by the lock file)
+  # needs Python >=3.10, so it's installed via pipx (system Python) and run
+  # against a stdlib venv (modern virtualenv can't seed pip for 3.8 either).
+  functional-legacy:
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.8
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.8"
-      - name: Install Poetry and create the 3.8 virtualenv
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry and create the virtualenv
         run: |
           pipx install poetry==2.4.1
           poetry config virtualenvs.create false
@@ -81,19 +85,20 @@ jobs:
       - name: Test with pytest
         run: make test-functional
 
-  py38-django:
-    needs: py38-functional
+  django-legacy:
+    needs: functional-legacy
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python-version: ["3.8", "3.9"]
         django-version: ["2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.8
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.8"
-      - name: Install Poetry and create the 3.8 virtualenv
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry and create the virtualenv
         run: |
           pipx install poetry==2.4.1
           poetry config virtualenvs.create false
@@ -112,14 +117,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # https://docs.djangoproject.com/en/2.2/faq/install/#what-python-version-can-i-use-with-django
         # https://docs.djangoproject.com/en/3.2/faq/install/#what-python-version-can-i-use-with-django
-        python-version: ["3.9"]
-        django-version: ["2.2", "3.0", "3.1", "3.2"]
-
-        include:
-          - python-version: "3.10"
-            django-version: "3.2"
+        # Django 2.2-3.1 don't support Python 3.10+; those combos run in django-legacy.
+        python-version: ["3.10"]
+        django-version: ["3.2"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -144,7 +145,7 @@ jobs:
     strategy:
       matrix:
         # https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
         django-version: ["4.0", "4.1", "4.2"]
 
         include:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Migrated the HTTP client from `httpx` to `httpx2` on Python 3.10+.
+
 ## [6.2.1](https://github.com/uploadcare/pyuploadcare/compare/v6.2.0...v6.2.1) - 2025-09-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ ucare = 'pyuploadcare.ucare_cli.main:main'
 python = ">=3.8,<3.15"
 # TODO: once Python 3.8 and 3.9 support is dropped, remove the httpx entry and
 # the python marker on httpx2 (httpx2 requires Python 3.10+).
-httpx = {version = "^0.28.1", python = "<3.10"}
-httpx2 = {version = "^2.9.1", python = ">=3.10"}
+httpx = {version = "^0.28.1", markers = "python_version < '3.10'"}
+httpx2 = {version = "^2.9.1", markers = "python_version >= '3.10'"}
 pydantic = [
   {extras = ["email"], version = "^2.13.4", python = ">=3.9"},
   {extras = ["email"], version = "^2.10.6", python = "<3.9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ ucare = 'pyuploadcare.ucare_cli.main:main'
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.15"
-httpx = "^0.28.1"
+# TODO: once Python 3.8 and 3.9 support is dropped, remove the httpx entry and
+# the python marker on httpx2 (httpx2 requires Python 3.10+).
+httpx = {version = "^0.28.1", python = "<3.10"}
+httpx2 = {version = "^2.9.1", python = ">=3.10"}
 pydantic = [
   {extras = ["email"], version = "^2.13.4", python = ">=3.9"},
   {extras = ["email"], version = "^2.10.6", python = "<3.9"},

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 python_files = tests.py test_*.py *_tests.py
+# Alias `import httpx` -> httpx2 before pytest-vcr loads
+# TODO: remove after dropping httpx
+addopts = -p tests._vcr_httpx_alias

--- a/pyuploadcare/api/_httpx.py
+++ b/pyuploadcare/api/_httpx.py
@@ -1,0 +1,84 @@
+"""Compatibility layer for httpx / httpx2.
+
+TODO: once Python 3.8 and 3.9 support is dropped, this module can be removed
+entirely.
+"""
+
+import sys
+
+
+if sys.version_info >= (3, 10):
+    import httpx2 as httpx
+    from httpx2 import (
+        USE_CLIENT_DEFAULT,
+        Auth,
+        Headers,
+        HTTPError,
+        HTTPStatusError,
+        Request,
+        Response,
+        UnsupportedProtocol,
+    )
+    from httpx2._client import Client, UseClientDefault
+    from httpx2._types import (
+        AuthTypes,
+        CookieTypes,
+        HeaderTypes,
+        QueryParamTypes,
+        RequestContent,
+        RequestData,
+        RequestFiles,
+        TimeoutTypes,
+        URLTypes,
+    )
+    from httpx2._utils import to_bytes, to_str
+else:
+    import httpx
+    from httpx import (
+        USE_CLIENT_DEFAULT,
+        Auth,
+        Headers,
+        HTTPError,
+        HTTPStatusError,
+        Request,
+        Response,
+        UnsupportedProtocol,
+    )
+    from httpx._client import Client, UseClientDefault
+    from httpx._types import (
+        AuthTypes,
+        CookieTypes,
+        HeaderTypes,
+        QueryParamTypes,
+        RequestContent,
+        RequestData,
+        RequestFiles,
+        TimeoutTypes,
+        URLTypes,
+    )
+    from httpx._utils import to_bytes, to_str
+
+__all__ = [
+    "httpx",
+    "USE_CLIENT_DEFAULT",
+    "Auth",
+    "Headers",
+    "HTTPError",
+    "HTTPStatusError",
+    "Request",
+    "Response",
+    "UnsupportedProtocol",
+    "Client",
+    "UseClientDefault",
+    "AuthTypes",
+    "CookieTypes",
+    "HeaderTypes",
+    "QueryParamTypes",
+    "RequestContent",
+    "RequestData",
+    "RequestFiles",
+    "TimeoutTypes",
+    "URLTypes",
+    "to_bytes",
+    "to_str",
+]

--- a/pyuploadcare/api/api.py
+++ b/pyuploadcare/api/api.py
@@ -7,9 +7,8 @@ from time import time
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 from uuid import UUID
 
-from httpx._types import RequestFiles
-
 from pyuploadcare.api import entities, responses
+from pyuploadcare.api._httpx import RequestFiles
 from pyuploadcare.api.addon_entities import (
     AddonExecutionGeneralRequestData,
     AddonExecutionParams,

--- a/pyuploadcare/api/auth.py
+++ b/pyuploadcare/api/auth.py
@@ -3,8 +3,7 @@ import hmac
 from datetime import datetime, timezone
 from typing import Generator, Union
 
-from httpx import Auth, Request, Response
-from httpx._utils import to_bytes, to_str
+from pyuploadcare.api._httpx import Auth, Request, Response, to_bytes, to_str
 
 
 class AuthBase(Auth): ...

--- a/pyuploadcare/api/auth.py
+++ b/pyuploadcare/api/auth.py
@@ -76,7 +76,7 @@ class UploadcareAuth(UploadcareSimpleAuth):
         formated_date_time: str = "",
     ) -> str:
         content_md5 = hashlib.md5(request.read()).hexdigest()
-        content_type = request.headers.get("Content-Type")
+        content_type = request.headers.get("Content-Type") or ""
         uri = to_str(request.url.raw_path)
         sign_string = "\n".join(
             [

--- a/pyuploadcare/api/base.py
+++ b/pyuploadcare/api/base.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, Optional, Type, Union, cast
 from urllib.parse import urlencode, urljoin
 from uuid import UUID
 
-from httpx._types import RequestFiles
 from pydantic import TypeAdapter
 from typing_extensions import Protocol, TypeVar
 
+from pyuploadcare.api._httpx import RequestFiles
 from pyuploadcare.api.client import Client
 from pyuploadcare.api.entities import Entity, UUIDEntity
 from pyuploadcare.api.responses import PaginatedResponse, Response

--- a/pyuploadcare/api/client.py
+++ b/pyuploadcare/api/client.py
@@ -6,22 +6,22 @@ import time
 import typing
 from platform import python_implementation, python_version
 
-from httpx import USE_CLIENT_DEFAULT, HTTPStatusError, Response
-from httpx._client import Client as HTTPXClient
-from httpx._client import UseClientDefault
-from httpx._types import (
-    AuthTypes,
+from pyuploadcare import __version__
+from pyuploadcare.api._httpx import USE_CLIENT_DEFAULT, AuthTypes
+from pyuploadcare.api._httpx import Client as HTTPXClient
+from pyuploadcare.api._httpx import (
     CookieTypes,
     HeaderTypes,
+    HTTPStatusError,
     QueryParamTypes,
     RequestContent,
     RequestData,
     RequestFiles,
+    Response,
     TimeoutTypes,
     URLTypes,
+    UseClientDefault,
 )
-
-from pyuploadcare import __version__
 from pyuploadcare.exceptions import (
     APIError,
     AuthenticationError,

--- a/pyuploadcare/ucare_cli/commands/sync.py
+++ b/pyuploadcare/ucare_cli/commands/sync.py
@@ -7,9 +7,9 @@ import time
 from math import ceil
 
 from dateutil import parser
-from httpx import HTTPError
 
 from pyuploadcare import FileList, conf
+from pyuploadcare.api._httpx import HTTPError
 from pyuploadcare.api.client import Client
 from pyuploadcare.client import Uploadcare
 from pyuploadcare.ucare_cli.commands.helpers import (

--- a/tests/_vcr_httpx_alias.py
+++ b/tests/_vcr_httpx_alias.py
@@ -1,0 +1,12 @@
+"""Early pytest plugin: alias `import httpx` to httpx2 before vcrpy loads.
+
+TODO: remove once Python 3.8 and 3.9 support is dropped
+"""
+
+import sys
+
+
+if sys.version_info >= (3, 10):
+    from httpx2 import alias_httpx
+
+    alias_httpx()

--- a/tests/functional/api/test_throttling_header.py
+++ b/tests/functional/api/test_throttling_header.py
@@ -2,8 +2,8 @@ from typing import Optional, Union
 from unittest.mock import MagicMock
 
 import pytest
-from httpx import Headers
 
+from pyuploadcare.api._httpx import Headers
 from pyuploadcare.exceptions import DEFAULT_RETRY_AFTER, ThrottledRequestError
 
 

--- a/tests/functional/test_client_arguments.py
+++ b/tests/functional/test_client_arguments.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
-import httpx
 import pytest
 
 import pyuploadcare.api.client
+from pyuploadcare.api._httpx import httpx
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

- httpx is abandonware.
- move to httpx2 for python3.10+
